### PR TITLE
Remove the hyperlink from 'www'

### DIFF
--- a/src/content/docs/Patchstack App/app-errors.md
+++ b/src/content/docs/Patchstack App/app-errors.md
@@ -18,7 +18,7 @@ Sometimes, due to wrong configurations, you may get some alerts in Patchstack Ap
 1. Check if the Patchstack plugin is activated on your WordPress site
 2. Check if the **API key** is correct on your WordPress plugin. To see the API Key, click on the **Settings** from the submenu of your application in the Patchstack App. Access the Patchstack plugin from **Settings > Security** on your WordPress site.
 3. Check if your site is publicly accessible and is not protected by any passwords. When you visit your site, can you see the content right away, or is there something blocking it?
-4. Check that the domain name would be correct. Click on the **Settings** from the submenu of your application in the Patchstack App. Check that the URL uses the correct protocol (http\:// or https://). Also, check if your site uses "www." or not. The URL **must be correct**.
+4. Check that the domain name would be correct. Click on the **Settings** from the submenu of your application in the Patchstack App. Check that the URL uses the correct protocol (http\:// or https://). Also, check if your site uses "www\." or not. The URL **must be correct**.
 5. If none of the above seem to cause the problem, contact our support via chat.
 
 ## Failed to load the site settings, contact support.

--- a/src/content/docs/Patchstack App/app-errors.md
+++ b/src/content/docs/Patchstack App/app-errors.md
@@ -18,7 +18,7 @@ Sometimes, due to wrong configurations, you may get some alerts in Patchstack Ap
 1. Check if the Patchstack plugin is activated on your WordPress site
 2. Check if the **API key** is correct on your WordPress plugin. To see the API Key, click on the **Settings** from the submenu of your application in the Patchstack App. Access the Patchstack plugin from **Settings > Security** on your WordPress site.
 3. Check if your site is publicly accessible and is not protected by any passwords. When you visit your site, can you see the content right away, or is there something blocking it?
-4. Check that the domain name would be correct. Click on the **Settings** from the submenu of your application in the Patchstack App. Check that the URL uses the correct protocol (http\:// or https://). Also, check if your site uses "www\." or not. The URL **must be correct**.
+4. Check that the domain name would be correct. Click on the **Settings** from the submenu of your application in the Patchstack App. Check that the URL uses the correct protocol (http\:// or https://). Also, check if your site uses "www\" or not. The URL **must be correct**.
 5. If none of the above seem to cause the problem, contact our support via chat.
 
 ## Failed to load the site settings, contact support.


### PR DESCRIPTION
On this page:

https://docs.patchstack.com/patchstack-app/app-errors/

Point 4 of 'Failed to load the component data, contact support.' displays "www" as a hyperlink which results in a broken link. 

I have added a backslash before the dots in "www." so Markdown will interpret them as literal characters rather than HTML tags for hyperlinks