### PR TITLE
Update API label/badge and clean banner whitespace

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -73,7 +73,7 @@ export default defineConfig({
 	banner: {
 		enabled: false,
 		content: 'Black Friday Deal - <a href="https://patchstack.com/black-friday-2024/" target="about:blank">50% off dev plan for 6 months</a>',
-	
+
 	},
 	integrations: [
 		postmanFromOpenAPI(),
@@ -147,8 +147,8 @@ export default defineConfig({
 								{ slug: 'api-solutions/threat-intelligence-api/extended' },
 								{ slug: 'api-solutions/threat-intelligence-api/api-properties' },
 								{
-									label: 'Beta API',
-									badge: { text: 'New', variant: 'tip' },
+									label: 'NPM standard API',
+									badge: { text: 'Beta', variant: 'tip' },
 									collapsed: true,
 									items: [
 										{ slug: 'api-solutions/threat-intelligence-api/beta' },

--- a/src/content/docs/API solutions/Threat Intelligence API/beta.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/beta.md
@@ -1,5 +1,5 @@
 ---
-title: "Beta API"
+title: "Npm Dataset API (Beta)"
 excerpt: "Beta vulnerability endpoints — npm support, Resource-based shape, offset and cursor pagination, include=details."
 hidden: false
 metadata:
@@ -11,7 +11,7 @@ sidebar:
   label: "Guide"
 ---
 
-_The Beta API is a new generation of the Threat Intelligence API, currently available to **selected partners working directly with Patchstack**. It lives alongside the v2 API (Standard / Extended) and adds npm coverage, an optional full advisory body, a consistent nested response shape, and cursor pagination. If you'd like access to run an integration on Beta, [contact us](https://patchstack.com/for-hosts/)._
+_The Npm Dataset API (Beta) is a new generation of the Threat Intelligence API, currently available to **selected partners working directly with Patchstack**. It lives alongside the v2 API (Standard / Extended) and adds npm coverage, an optional full advisory body, a consistent nested response shape, and cursor pagination. If you'd like access to run an integration on Beta, [contact us](https://patchstack.com/for-hosts/)._
 
 > **Interactive reference:** Every endpoint, parameter, request body and response shape is documented in the [Threat Intelligence API (Beta) reference](/api-reference/threat-intelligence-beta/).
 

--- a/src/content/docs/API solutions/Threat Intelligence API/overview.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 excerpt: ""
-metadata: 
+metadata:
   image: []
   robots: "index"
 createdAt: "Thu Jun 01 2023 12:04:17 GMT+0000 (Coordinated Universal Time)"
@@ -12,7 +12,7 @@ sidebar:
   hidden: false
 ---
 
-Patchstack publishes three ways to consume its vulnerability database. Standard and Extended are the stable tiers of the v2 API; the Beta API is a new generation available to selected partners only.
+Patchstack publishes three ways to consume its vulnerability database. Standard and Extended are the stable tiers of the v2 API; the Npm Dataset API (Beta) is a new generation available to selected partners only.
 
 ## Which API should I use?
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -72,7 +72,7 @@ header button {
 	--sl-color-black: #ffffff;
 	--sl-color-bg-nav: #24272f;
 	--sl-color-text-invert:#24272f;
-	
+
 
 	starlight-theme-select select,
 	starlight-theme-select option,
@@ -111,7 +111,7 @@ header button {
 	border: 0;
 }
 .tagline {
-	font-family: Faktum Regular, sans-serif;	
+	font-family: Faktum Regular, sans-serif;
 	font-size: 1rem;
 	line-height: var(--sl-line-height);
 }
@@ -137,7 +137,7 @@ header button {
 	margin-bottom: 30px;
 }
 
-/* Match sidebar group labels that carry a badge (e.g. Beta API [New]) to the
+/* Match sidebar group labels that carry a badge (e.g. Npm Dataset API (Beta) [New]) to the
    weight/size of sibling leaf links, so the badge carries the emphasis
    instead of the label doubling up. */
 .group-label .large:has(+ .sl-badge) {


### PR DESCRIPTION
Rename the navigation label for the Threat Intelligence API from "Beta API" to "NPM standard API" and change the badge text from "New" to "Beta" (badge variant remains "tip"). Also remove an extra blank/whitespace line after the banner content in astro.config.mjs. These are non-functional wording/formatting updates.