### PR TITLE
Threat Intelligence Standard + Extended: OpenAPI specs, interactive reference, Postman

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,8 +3,12 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, passthroughImageService } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLlmsTxt from 'starlight-llms-txt'
-import starlightOpenAPI, { openAPISidebarGroups } from 'starlight-openapi'
+import starlightOpenAPI, { createOpenAPISidebarGroup } from 'starlight-openapi'
 import Converter from 'openapi-to-postmanv2'
+
+const threatIntelStandardSidebarGroup = createOpenAPISidebarGroup();
+const threatIntelExtendedSidebarGroup = createOpenAPISidebarGroup();
+const threatIntelBetaSidebarGroup     = createOpenAPISidebarGroup();
 
 
 const site_url = process.env.URL;
@@ -12,6 +16,14 @@ const site_url = process.env.URL;
 const site = site_url || 'http://localhost:4321';
 
 const postmanCollections = [
+	{
+		openapi: './public/schemas/threat-intel-standard.yaml',
+		output:  './public/schemas/threat-intel-standard.postman_collection.json',
+	},
+	{
+		openapi: './public/schemas/threat-intel-extended.yaml',
+		output:  './public/schemas/threat-intel-extended.postman_collection.json',
+	},
 	{
 		openapi: './public/schemas/threat-intel-beta.yaml',
 		output:  './public/schemas/threat-intel-beta.postman_collection.json',
@@ -82,9 +94,19 @@ export default defineConfig({
 				starlightLlmsTxt(),
 				starlightOpenAPI([
 					{
+						base: 'api-reference/threat-intelligence-standard',
+						schema: './public/schemas/threat-intel-standard.yaml',
+						sidebar: { label: 'Reference', group: threatIntelStandardSidebarGroup },
+					},
+					{
+						base: 'api-reference/threat-intelligence-extended',
+						schema: './public/schemas/threat-intel-extended.yaml',
+						sidebar: { label: 'Reference', group: threatIntelExtendedSidebarGroup },
+					},
+					{
 						base: 'api-reference/threat-intelligence-beta',
-						label: 'Reference',
 						schema: './public/schemas/threat-intel-beta.yaml',
+						sidebar: { label: 'Reference', group: threatIntelBetaSidebarGroup },
 					},
 				]),
 			],
@@ -143,18 +165,32 @@ export default defineConfig({
 							collapsed: true,
 							items: [
 								{ slug: 'api-solutions/threat-intelligence-api/overview' },
-								{ slug: 'api-solutions/threat-intelligence-api/standard' },
-								{ slug: 'api-solutions/threat-intelligence-api/extended' },
-								{ slug: 'api-solutions/threat-intelligence-api/api-properties' },
+								{
+									label: 'Standard API',
+									collapsed: true,
+									items: [
+										{ slug: 'api-solutions/threat-intelligence-api/standard' },
+										threatIntelStandardSidebarGroup,
+									],
+								},
+								{
+									label: 'Extended API',
+									collapsed: true,
+									items: [
+										{ slug: 'api-solutions/threat-intelligence-api/extended' },
+										threatIntelExtendedSidebarGroup,
+									],
+								},
 								{
 									label: 'NPM standard API',
 									badge: { text: 'Beta', variant: 'tip' },
 									collapsed: true,
 									items: [
 										{ slug: 'api-solutions/threat-intelligence-api/beta' },
-										...openAPISidebarGroups,
+										threatIntelBetaSidebarGroup,
 									],
 								},
+								{ slug: 'api-solutions/threat-intelligence-api/api-properties' },
 							],
 						},
 					],

--- a/netlify.toml
+++ b/netlify.toml
@@ -666,7 +666,11 @@
 
 [[redirects]]
 	from = "/docs/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-127001-or-other-security-checks"
-	to = "/faq-troubleshooting/technical/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-127001-or-other-security-checks/"
+	to = "/faq-troubleshooting/technical/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-27001-or-other-security-checks/"
+
+[[redirects]]
+	from = "/faq-troubleshooting/technical/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-127001-or-other-security-checks"
+	to = "/faq-troubleshooting/technical/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-27001-or-other-security-checks/"
 
 [[redirects]]
 	from = "/docs/updating-patchstack-from-2020"

--- a/public/schemas/threat-intel-extended.postman_collection.json
+++ b/public/schemas/threat-intel-extended.postman_collection.json
@@ -1,0 +1,1494 @@
+{
+  "item": [
+    {
+      "name": "Latest vulnerabilities",
+      "request": {
+        "name": "Latest vulnerabilities",
+        "description": {
+          "content": "Return the 20 most recently added vulnerabilities, ordered by\ndescending `created_at` (insertion time, not `disclosure_date`).\n",
+          "type": "text/plain"
+        },
+        "url": {
+          "path": [
+            "latest"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "name": "The 20 most recent vulnerabilities.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "latest"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\n  \"vulnerabilities\": [\n    {\n      \"id\": 7976,\n      \"product_id\": 2175,\n      \"title\": \"WordPress File Upload plugin <= 4.16.2 - Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE)\",\n      \"description\": \"Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE) discovered by apple502j in WordPress File Upload plugin (versions <= 4.16.2).\",\n      \"disclosed_at\": \"2022-03-01T00:00:00+00:00\",\n      \"created_at\": \"2022-03-07T11:17:05+00:00\",\n      \"url\": \"wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"product_slug\": \"wp-file-upload\",\n      \"product_name\": \"WordPress File Upload\",\n      \"product_type\": \"Plugin\",\n      \"vuln_type\": \"Directory Traversal\",\n      \"cve\": [\n        \"2021-24962\"\n      ],\n      \"affected_in\": \"<= 4.16.2\",\n      \"fixed_in\": \"4.16.3\",\n      \"direct_url\": \"https://patchstack.com/database/vulnerability/wp-file-upload/wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"disclosure_date\": \"2022-03-01 00:00:00\",\n      \"product_name_premium\": null,\n      \"cvss_score\": 8.8,\n      \"is_exploited\": false,\n      \"patch_priority\": 3,\n      \"patched_in_ranges\": [\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        },\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        }\n      ]\n    },\n    {\n      \"id\": 7976,\n      \"product_id\": 2175,\n      \"title\": \"WordPress File Upload plugin <= 4.16.2 - Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE)\",\n      \"description\": \"Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE) discovered by apple502j in WordPress File Upload plugin (versions <= 4.16.2).\",\n      \"disclosed_at\": \"2022-03-01T00:00:00+00:00\",\n      \"created_at\": \"2022-03-07T11:17:05+00:00\",\n      \"url\": \"wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"product_slug\": \"wp-file-upload\",\n      \"product_name\": \"WordPress File Upload\",\n      \"product_type\": \"Plugin\",\n      \"vuln_type\": \"Directory Traversal\",\n      \"cve\": [\n        \"2021-24962\"\n      ],\n      \"affected_in\": \"<= 4.16.2\",\n      \"fixed_in\": \"4.16.3\",\n      \"direct_url\": \"https://patchstack.com/database/vulnerability/wp-file-upload/wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"disclosure_date\": \"2022-03-01 00:00:00\",\n      \"product_name_premium\": null,\n      \"cvss_score\": 8.8,\n      \"is_exploited\": false,\n      \"patch_priority\": 3,\n      \"patched_in_ranges\": [\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        },\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        }\n      ]\n    }\n  ]\n}",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        },
+        {
+          "name": "Missing or invalid `PSKey` header.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "latest"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Unauthorized",
+          "code": 401,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "API key not authorised for the requested endpoint.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "latest"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Forbidden",
+          "code": 403,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "Rate limit exceeded.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "latest"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Too Many Requests",
+          "code": 429,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": [],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      }
+    },
+    {
+      "name": "product/{type}/{name}/{version}",
+      "item": [
+        {
+          "name": "Find vulnerabilities for a product",
+          "request": {
+            "name": "Find vulnerabilities for a product",
+            "description": {
+              "content": "Match a specific WordPress plugin, theme or core version and return\nevery applicable advisory with the full Extended payload.\n",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "product",
+                ":type",
+                ":name",
+                ":version"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "plugin",
+                  "key": "type",
+                  "description": "(Required) Product ecosystem."
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "tutor",
+                  "key": "name",
+                  "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "1.5.2",
+                  "key": "version",
+                  "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "name": "Matched advisories (possibly empty).",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"vulnerabilities\": [\n    {\n      \"id\": 7976,\n      \"product_id\": 2175,\n      \"title\": \"WordPress File Upload plugin <= 4.16.2 - Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE)\",\n      \"description\": \"Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE) discovered by apple502j in WordPress File Upload plugin (versions <= 4.16.2).\",\n      \"disclosed_at\": \"2022-03-01T00:00:00+00:00\",\n      \"created_at\": \"2022-03-07T11:17:05+00:00\",\n      \"url\": \"wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"product_slug\": \"wp-file-upload\",\n      \"product_name\": \"WordPress File Upload\",\n      \"product_type\": \"Plugin\",\n      \"vuln_type\": \"Directory Traversal\",\n      \"cve\": [\n        \"2021-24962\"\n      ],\n      \"affected_in\": \"<= 4.16.2\",\n      \"fixed_in\": \"4.16.3\",\n      \"direct_url\": \"https://patchstack.com/database/vulnerability/wp-file-upload/wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"disclosure_date\": \"2022-03-01 00:00:00\",\n      \"product_name_premium\": null,\n      \"cvss_score\": 8.8,\n      \"is_exploited\": false,\n      \"patch_priority\": 3,\n      \"patched_in_ranges\": [\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        },\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        }\n      ]\n    },\n    {\n      \"id\": 7976,\n      \"product_id\": 2175,\n      \"title\": \"WordPress File Upload plugin <= 4.16.2 - Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE)\",\n      \"description\": \"Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE) discovered by apple502j in WordPress File Upload plugin (versions <= 4.16.2).\",\n      \"disclosed_at\": \"2022-03-01T00:00:00+00:00\",\n      \"created_at\": \"2022-03-07T11:17:05+00:00\",\n      \"url\": \"wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"product_slug\": \"wp-file-upload\",\n      \"product_name\": \"WordPress File Upload\",\n      \"product_type\": \"Plugin\",\n      \"vuln_type\": \"Directory Traversal\",\n      \"cve\": [\n        \"2021-24962\"\n      ],\n      \"affected_in\": \"<= 4.16.2\",\n      \"fixed_in\": \"4.16.3\",\n      \"direct_url\": \"https://patchstack.com/database/vulnerability/wp-file-upload/wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce\",\n      \"disclosure_date\": \"2022-03-01 00:00:00\",\n      \"product_name_premium\": null,\n      \"cvss_score\": 8.8,\n      \"is_exploited\": false,\n      \"patch_priority\": 3,\n      \"patched_in_ranges\": [\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        },\n        {\n          \"from_version\": \"3.0\",\n          \"to_version\": \"3.0.34.1\",\n          \"fixed_in\": \"3.0.34.2\"\n        }\n      ]\n    }\n  ]\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "name": "Missing or invalid `PSKey` header.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "API key not authorised for the requested endpoint.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "Unknown product/version/vulnerability id.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "Rate limit exceeded.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "name": "Boolean exists check for a product",
+          "request": {
+            "name": "Boolean exists check for a product",
+            "description": {
+              "content": "Boolean-only variant of the product lookup. Returns\n`{ \"vulnerable\": true }` or `{ \"vulnerable\": false }` — cheap when you\nonly need to know whether an installed version is affected.\n",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "product",
+                ":type",
+                ":name",
+                ":version",
+                "exists"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "plugin",
+                  "key": "type",
+                  "description": "(Required) Product ecosystem."
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "tutor",
+                  "key": "name",
+                  "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "1.5.2",
+                  "key": "version",
+                  "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "name": "Boolean result.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"vulnerable\": true\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "name": "Missing or invalid `PSKey` header.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "API key not authorised for the requested endpoint.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "Rate limit exceeded.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        }
+      ],
+      "event": []
+    },
+    {
+      "name": "Bulk product check",
+      "request": {
+        "name": "Bulk product check",
+        "description": {
+          "content": "Check up to 50 products in a single request. Items with `exists: true`\nreturn a boolean per slug; items with `exists: false` return the full\nadvisory list per slug.\n\nThe response is keyed by `product_slug`, **not** by array index —\nduplicate slugs in the request collapse.\n",
+          "type": "text/plain"
+        },
+        "url": {
+          "path": [
+            "batch"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "method": "POST",
+        "auth": null,
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"name\": \"easy-digital-downloads1\",\n    \"version\": \"1.0.0\",\n    \"type\": \"plugin\",\n    \"exists\": true\n  },\n  {\n    \"name\": \"wordpress\",\n    \"version\": \"3.0.0\",\n    \"type\": \"wordpress\",\n    \"exists\": true\n  }\n]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        }
+      },
+      "response": [
+        {
+          "name": "Per-slug results.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "batch"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"name\": \"easy-digital-downloads1\",\n    \"version\": \"1.0.0\",\n    \"type\": \"plugin\",\n    \"exists\": true\n  },\n  {\n    \"name\": \"wordpress\",\n    \"version\": \"3.0.0\",\n    \"type\": \"wordpress\",\n    \"exists\": true\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\n  \"vulnerabilities\": {\n    \"easy-digital-downloads1\": true,\n    \"wordpress\": true\n  }\n}",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        },
+        {
+          "name": "Missing or invalid `PSKey` header.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "batch"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"name\": \"easy-digital-downloads1\",\n    \"version\": \"1.0.0\",\n    \"type\": \"plugin\",\n    \"exists\": true\n  },\n  {\n    \"name\": \"wordpress\",\n    \"version\": \"3.0.0\",\n    \"type\": \"wordpress\",\n    \"exists\": true\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Unauthorized",
+          "code": 401,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "API key not authorised for the requested endpoint.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "batch"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"name\": \"easy-digital-downloads1\",\n    \"version\": \"1.0.0\",\n    \"type\": \"plugin\",\n    \"exists\": true\n  },\n  {\n    \"name\": \"wordpress\",\n    \"version\": \"3.0.0\",\n    \"type\": \"wordpress\",\n    \"exists\": true\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Forbidden",
+          "code": 403,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "Invalid request payload (e.g. batch with more than 50 items).",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "batch"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"name\": \"easy-digital-downloads1\",\n    \"version\": \"1.0.0\",\n    \"type\": \"plugin\",\n    \"exists\": true\n  },\n  {\n    \"name\": \"wordpress\",\n    \"version\": \"3.0.0\",\n    \"type\": \"wordpress\",\n    \"exists\": true\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+          "code": 422,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "Rate limit exceeded.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "batch"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"name\": \"easy-digital-downloads1\",\n    \"version\": \"1.0.0\",\n    \"type\": \"plugin\",\n    \"exists\": true\n  },\n  {\n    \"name\": \"wordpress\",\n    \"version\": \"3.0.0\",\n    \"type\": \"wordpress\",\n    \"exists\": true\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Too Many Requests",
+          "code": 429,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": [],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      }
+    },
+    {
+      "name": "Find a vulnerability by id",
+      "request": {
+        "name": "Find a vulnerability by id",
+        "description": {
+          "content": "Look up a single advisory by its numeric id or PSID. Returns a richer\nshape than the list endpoints — includes CVSS vector, OWASP category,\nexternal references, credits, and submitter info.\n",
+          "type": "text/plain"
+        },
+        "url": {
+          "path": [
+            "vulnerability",
+            ":id"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": [
+            {
+              "disabled": false,
+              "type": "any",
+              "value": "4760",
+              "key": "id",
+              "description": "(Required) Numeric Patchstack id or PSID."
+            }
+          ]
+        },
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "name": "Detailed advisory payload.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "vulnerability",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "4760",
+                  "key": "id",
+                  "description": "(Required) Numeric Patchstack id or PSID."
+                }
+              ]
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\n  \"vulnerability\": {\n    \"title\": \"WordPress Spam protection, AntiSpam, FireWall by CleanTalk plugin <= 5.153.3 - Unauthenticated Time-Based Blind SQL Injection (SQLi) vulnerability\",\n    \"description\": \"Unauthenticated Time-Based Blind SQL Injection (SQLi) vulnerability discovered by WordFence in WordPress Spam protection, AntiSpam, FireWall by CleanTalk plugin (versions <= 5.153.3).\",\n    \"disclosed_at\": \"2021-05-03T00:00:00+00:00\",\n    \"created_at\": \"2021-09-28T14:17:02+00:00\",\n    \"is_exploited\": true,\n    \"url\": \"wordpress-spam-protection-antispam-firewall-by-cleantalk-plugin-5-153-3-unauthenticated-time-based-blind-sql-injection-sqli-vulnerability\",\n    \"direct_url\": \"https://patchstack.com/database/vulnerability/cleantalk-spam-protect/wordpress-spam-protection-antispam-firewall-by-cleantalk-plugin-5-153-3-unauthenticated-time-based-blind-sql-injection-sqli-vulnerability\",\n    \"disclosure_date\": \"2021-05-03 00:00:00\"\n  },\n  \"product\": {\n    \"name\": \"Spam protection, AntiSpam, FireWall by CleanTalk\",\n    \"slug\": \"cleantalk-spam-protect\",\n    \"type\": \"Plugin\"\n  },\n  \"type\": \"SQL Injection\",\n  \"cve\": [\n    \"2021-24295\"\n  ],\n  \"versions\": {\n    \"affected_in\": \"<= 5.153.3\",\n    \"fixed_in\": \"5.153.4\"\n  },\n  \"cvss\": {\n    \"score\": 7.5,\n    \"vector\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N\",\n    \"description\": \"\"\n  },\n  \"owasp\": \"A1: Injection\",\n  \"references_url\": [\n    {\n      \"url\": \"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24295\",\n      \"title\": \"CVE\"\n    },\n    {\n      \"url\": \"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24295\",\n      \"title\": \"CVE\"\n    }\n  ],\n  \"versions_list\": null,\n  \"credit\": {\n    \"name\": \"WordFence\",\n    \"url\": \"https://twitter.com/wordfence\"\n  },\n  \"submitter\": {\n    \"name\": \"h00die\",\n    \"url\": \"https://packetstormsecurity.com/files/author/7166/\"\n  }\n}",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        },
+        {
+          "name": "Missing or invalid `PSKey` header.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "vulnerability",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "4760",
+                  "key": "id",
+                  "description": "(Required) Numeric Patchstack id or PSID."
+                }
+              ]
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Unauthorized",
+          "code": 401,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "API key not authorised for the requested endpoint.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "vulnerability",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "4760",
+                  "key": "id",
+                  "description": "(Required) Numeric Patchstack id or PSID."
+                }
+              ]
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Forbidden",
+          "code": 403,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "Unknown product/version/vulnerability id.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "vulnerability",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "4760",
+                  "key": "id",
+                  "description": "(Required) Numeric Patchstack id or PSID."
+                }
+              ]
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Not Found",
+          "code": 404,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        },
+        {
+          "name": "Rate limit exceeded.",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "vulnerability",
+                ":id"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "4760",
+                  "key": "id",
+                  "description": "(Required) Numeric Patchstack id or PSID."
+                }
+              ]
+            },
+            "header": [
+              {
+                "description": {
+                  "content": "Added as a part of security scheme: apikey",
+                  "type": "text/plain"
+                },
+                "key": "PSKey",
+                "value": "<API Key>"
+              }
+            ],
+            "method": "GET",
+            "body": {}
+          },
+          "status": "Too Many Requests",
+          "code": 429,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": [],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      }
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "https://patchstack.com/database/api/v2",
+      "key": "baseUrl"
+    }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "key",
+        "value": "PSKey"
+      },
+      {
+        "key": "value",
+        "value": "{{apiKey}}"
+      },
+      {
+        "key": "in",
+        "value": "header"
+      }
+    ]
+  },
+  "info": {
+    "name": "Patchstack Threat Intelligence API — Extended",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "The Extended Threat Intelligence API is a superset of the\n[Standard tier](/api-solutions/threat-intelligence-api/standard/). It adds\nbulk product checks, the `/latest` rolling feed, advisory-by-id lookups,\nand a richer per-item payload (`description`, `cvss_score`, `cve`,\n`patch_priority`, `patched_in_ranges`, …).\n\nExtended has **custom pricing and is activated on request** — contact us\nat <https://patchstack.com/for-hosts/>.\n\n## Authentication\n\nEvery request must include your API key in the `PSKey` HTTP request header.\n\n## Rate limiting\n\nCustom, set per contract. Contact <https://patchstack.com/for-hosts/> if\nyou need a quota change.\n\n## Caching\n\nResponses are JSON and cached until the Patchstack database updates, at\nwhich point the appropriate caches are cleared.\n\n## Errors\n\n| Status | Meaning |\n|---|---|\n| `401` | Missing or invalid `PSKey` header. |\n| `403` | API key not authorised for the requested endpoint. |\n| `404` | Unknown product/version/vulnerability id. |\n| `422` | Invalid request payload (e.g. batch with more than 50 items). |\n| `429` | Rate limit exceeded. |\n| `500` | Server error — include the request id in any bug report. |\n\n## Related pages\n\n- Narrative guide with code samples: [Extended tier API](/api-solutions/threat-intelligence-api/extended/)\n- Field glossary: [API properties](/api-solutions/threat-intelligence-api/api-properties/)\n- OpenAPI spec (import into Postman / Insomnia / Bruno / Hoppscotch): <https://docs.patchstack.com/schemas/threat-intel-extended.yaml>\n- Postman collection (pre-imported): <https://docs.patchstack.com/schemas/threat-intel-extended.postman_collection.json>\n\nIntegration questions: <dave.jong@patchstack.com>.\n\n\nContact Support:\n Name: Patchstack\n Email: dave.jong@patchstack.com",
+      "type": "text/plain"
+    }
+  }
+}

--- a/public/schemas/threat-intel-extended.yaml
+++ b/public/schemas/threat-intel-extended.yaml
@@ -1,0 +1,643 @@
+openapi: 3.1.0
+info:
+  title: Patchstack Threat Intelligence API — Extended
+  version: v2
+  summary: WordPress vulnerability intelligence with bulk lookups, latest-24h feed, and advisory-by-id details.
+  description: |
+    The Extended Threat Intelligence API is a superset of the
+    [Standard tier](/api-solutions/threat-intelligence-api/standard/). It adds
+    bulk product checks, the `/latest` rolling feed, advisory-by-id lookups,
+    and a richer per-item payload (`description`, `cvss_score`, `cve`,
+    `patch_priority`, `patched_in_ranges`, …).
+
+    Extended has **custom pricing and is activated on request** — contact us
+    at <https://patchstack.com/for-hosts/>.
+
+    ## Authentication
+
+    Every request must include your API key in the `PSKey` HTTP request header.
+
+    ## Rate limiting
+
+    Custom, set per contract. Contact <https://patchstack.com/for-hosts/> if
+    you need a quota change.
+
+    ## Caching
+
+    Responses are JSON and cached until the Patchstack database updates, at
+    which point the appropriate caches are cleared.
+
+    ## Errors
+
+    | Status | Meaning |
+    |---|---|
+    | `401` | Missing or invalid `PSKey` header. |
+    | `403` | API key not authorised for the requested endpoint. |
+    | `404` | Unknown product/version/vulnerability id. |
+    | `422` | Invalid request payload (e.g. batch with more than 50 items). |
+    | `429` | Rate limit exceeded. |
+    | `500` | Server error — include the request id in any bug report. |
+
+    ## Related pages
+
+    - Narrative guide with code samples: [Extended tier API](/api-solutions/threat-intelligence-api/extended/)
+    - Field glossary: [API properties](/api-solutions/threat-intelligence-api/api-properties/)
+    - OpenAPI spec (import into Postman / Insomnia / Bruno / Hoppscotch): <https://docs.patchstack.com/schemas/threat-intel-extended.yaml>
+    - Postman collection (pre-imported): <https://docs.patchstack.com/schemas/threat-intel-extended.postman_collection.json>
+
+    Integration questions: <dave.jong@patchstack.com>.
+  contact:
+    name: Patchstack
+    url: https://patchstack.com/for-hosts/
+    email: dave.jong@patchstack.com
+
+servers:
+  - url: https://patchstack.com/database/api/v2
+    description: Production
+
+security:
+  - PSKey: []
+
+tags:
+  - name: Vulnerabilities
+    description: |
+      Feed and advisory-by-id lookups.
+
+      - [`GET /latest`](/api-reference/threat-intelligence-extended/operations/listlatestvulnerabilities/)
+        — the 20 most recently added vulnerabilities.
+      - [`GET /vulnerability/{id}`](/api-reference/threat-intelligence-extended/operations/getvulnerabilitybyid/)
+        — detailed advisory payload for a single Patchstack id or PSID.
+  - name: Products
+    description: |
+      Match a single WordPress plugin, theme or core version against the
+      vulnerability database.
+
+      - [`GET /product/{type}/{name}/{version}`](/api-reference/threat-intelligence-extended/operations/findproductvulnerabilities/)
+        — full advisory list for the product.
+      - [`GET /product/{type}/{name}/{version}/exists`](/api-reference/threat-intelligence-extended/operations/productvulnerabilityexists/)
+        — boolean-only variant for fast "is this vulnerable?" checks.
+  - name: Batch
+    description: |
+      Bulk endpoint for checking up to 50 products in a single request. Use
+      this when walking a list of installed plugins/themes — it's significantly
+      cheaper than issuing one request per product.
+
+      - [`POST /batch`](/api-reference/threat-intelligence-extended/operations/batchproductcheck/)
+        — payload is a JSON array of up to 50 `{type, name, version, exists?}`
+        objects. Results are keyed by slug.
+
+paths:
+  /latest:
+    get:
+      tags: [Vulnerabilities]
+      summary: Latest vulnerabilities
+      description: |
+        Return the 20 most recently added vulnerabilities, ordered by
+        descending `created_at` (insertion time, not `disclosure_date`).
+      operationId: listLatestVulnerabilities
+      responses:
+        '200':
+          description: The 20 most recent vulnerabilities.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [vulnerabilities]
+                properties:
+                  vulnerabilities:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExtendedVulnerability'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /product/{type}/{name}/{version}:
+    get:
+      tags: [Products]
+      summary: Find vulnerabilities for a product
+      description: |
+        Match a specific WordPress plugin, theme or core version and return
+        every applicable advisory with the full Extended payload.
+      operationId: findProductVulnerabilities
+      parameters:
+        - $ref: '#/components/parameters/ProductType'
+        - $ref: '#/components/parameters/ProductName'
+        - $ref: '#/components/parameters/ProductVersion'
+      responses:
+        '200':
+          description: Matched advisories (possibly empty).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [vulnerabilities]
+                properties:
+                  vulnerabilities:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExtendedVulnerability'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /product/{type}/{name}/{version}/exists:
+    get:
+      tags: [Products]
+      summary: Boolean exists check for a product
+      description: |
+        Boolean-only variant of the product lookup. Returns
+        `{ "vulnerable": true }` or `{ "vulnerable": false }` — cheap when you
+        only need to know whether an installed version is affected.
+      operationId: productVulnerabilityExists
+      parameters:
+        - $ref: '#/components/parameters/ProductType'
+        - $ref: '#/components/parameters/ProductName'
+        - $ref: '#/components/parameters/ProductVersion'
+      responses:
+        '200':
+          description: Boolean result.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [vulnerable]
+                properties:
+                  vulnerable:
+                    type: boolean
+              example:
+                vulnerable: true
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /batch:
+    post:
+      tags: [Batch]
+      summary: Bulk product check
+      description: |
+        Check up to 50 products in a single request. Items with `exists: true`
+        return a boolean per slug; items with `exists: false` return the full
+        advisory list per slug.
+
+        The response is keyed by `product_slug`, **not** by array index —
+        duplicate slugs in the request collapse.
+      operationId: batchProductCheck
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              maxItems: 50
+              items:
+                $ref: '#/components/schemas/BatchItem'
+            examples:
+              existsOnly:
+                summary: Boolean-only across all items
+                value:
+                  - { name: easy-digital-downloads1, version: "1.0.0", type: plugin, exists: true }
+                  - { name: wordpress,               version: "3.0.0", type: wordpress, exists: true }
+              mixed:
+                summary: Mix of full advisory list and boolean
+                value:
+                  - { name: easy-digital-downloads1, version: "1.0.0", type: plugin, exists: false }
+                  - { name: wordpress,               version: "3.0.0", type: wordpress, exists: true }
+      responses:
+        '200':
+          description: Per-slug results.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [vulnerabilities]
+                properties:
+                  vulnerabilities:
+                    type: object
+                    additionalProperties:
+                      oneOf:
+                        - type: boolean
+                        - type: array
+                          items:
+                            $ref: '#/components/schemas/ExtendedVulnerability'
+              examples:
+                existsOnly:
+                  summary: Boolean-only response
+                  value:
+                    vulnerabilities:
+                      easy-digital-downloads1: true
+                      wordpress: true
+                mixed:
+                  summary: Mixed response
+                  value:
+                    vulnerabilities:
+                      easy-digital-downloads1:
+                        - id: 4532
+                          product_id: 1572
+                          title: "WordPress Easy Digital Downloads plugin <= 2.10.2 - Cross-Site Request Forgery (CSRF) vulnerability"
+                          description: "Cross-Site Request Forgery (CSRF) vulnerability discovered by WPScan team in WordPress Easy Digital Downloads plugin (versions <= 2.10.2)."
+                          disclosure_date: "2021-04-16 00:00:00"
+                          disclosed_at: "2021-04-16T00:00:00+00:00"
+                          created_at: "2021-04-19T04:43:04+00:00"
+                          url: wordpress-easy-digital-downloads-plugin-2-10-2-cross-site-request-forgery-csrf-vulnerability
+                          product_slug: easy-digital-downloads1
+                          product_name: "Easy Digital Downloads"
+                          product_name_premium: null
+                          product_type: Plugin
+                          vuln_type: "Cross Site Request Forgery (CSRF)"
+                          cvss_score: 6.5
+                          cve: []
+                          is_exploited: false
+                          affected_in: "<= 2.10.2"
+                          fixed_in: "2.10.3"
+                          direct_url: "https://patchstack.com/database/vulnerability/easy-digital-downloads1/wordpress-easy-digital-downloads-plugin-2-10-2-cross-site-request-forgery-csrf-vulnerability"
+                      wordpress: true
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/UnprocessableEntity' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /vulnerability/{id}:
+    get:
+      tags: [Vulnerabilities]
+      summary: Find a vulnerability by id
+      description: |
+        Look up a single advisory by its numeric id or PSID. Returns a richer
+        shape than the list endpoints — includes CVSS vector, OWASP category,
+        external references, credits, and submitter info.
+      operationId: getVulnerabilityById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Numeric Patchstack id or PSID.
+          schema:
+            type: string
+            example: "4760"
+      responses:
+        '200':
+          description: Detailed advisory payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityDetail'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+components:
+  securitySchemes:
+    PSKey:
+      type: apiKey
+      in: header
+      name: PSKey
+      description: |
+        API key issued by Patchstack. Extended access is activated on request
+        — contact <https://patchstack.com/for-hosts/>.
+
+  parameters:
+    ProductType:
+      name: type
+      in: path
+      required: true
+      description: Product ecosystem.
+      schema:
+        type: string
+        enum: [plugin, theme, wordpress]
+        example: plugin
+    ProductName:
+      name: name
+      in: path
+      required: true
+      description: |
+        WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.
+        Slugs are lowercase — normalize your own data before comparison.
+      schema:
+        type: string
+        example: tutor
+    ProductVersion:
+      name: version
+      in: path
+      required: true
+      description: Concrete version (e.g. `1.5.2`).
+      schema:
+        type: string
+        example: "1.5.2"
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid `PSKey` header.
+    Forbidden:
+      description: API key not authorised for the requested endpoint.
+    NotFound:
+      description: Unknown product/version/vulnerability id.
+    UnprocessableEntity:
+      description: Invalid request payload (e.g. batch with more than 50 items).
+    TooManyRequests:
+      description: Rate limit exceeded.
+
+  schemas:
+    ExtendedVulnerability:
+      type: object
+      description: |
+        Flat per-item shape returned by the Extended tier. Superset of the
+        Standard shape — adds `description`, `vuln_type`, `cvss_score`, `cve`,
+        `is_exploited`, `patch_priority`, `affected_in`, and
+        `patched_in_ranges`.
+      required:
+        - id
+        - product_id
+        - title
+        - description
+        - disclosed_at
+        - created_at
+        - url
+        - product_slug
+        - product_name
+        - product_type
+        - vuln_type
+        - cve
+        - affected_in
+        - fixed_in
+        - direct_url
+      properties:
+        id:
+          type: integer
+          description: Stable Patchstack vulnerability id.
+          example: 7976
+        product_id:
+          type: integer
+          description: Stable Patchstack product id.
+          example: 2175
+        title:
+          type: string
+          description: Human-readable title including product name, affected version, and vulnerability type.
+          example: "WordPress File Upload plugin <= 4.16.2 - Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE)"
+        description:
+          type: string
+          description: Short narrative summary of the advisory.
+          example: "Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE) discovered by apple502j in WordPress File Upload plugin (versions <= 4.16.2)."
+        disclosure_date:
+          type: string
+          description: Disclosure date in `YYYY-MM-DD HH:MM:SS` form (legacy).
+          example: "2022-03-01 00:00:00"
+        disclosed_at:
+          type: string
+          format: date-time
+          description: Disclosure date in ISO 8601.
+          example: "2022-03-01T00:00:00+00:00"
+        created_at:
+          type: string
+          format: date-time
+          description: When the row was inserted into the Patchstack database (ISO 8601). Drives `/latest` windowing.
+          example: "2022-03-07T11:17:05+00:00"
+        url:
+          type: string
+          description: URL slug for the advisory.
+          example: wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce
+        product_slug:
+          type: string
+          description: Lowercase slug of the product.
+          example: wp-file-upload
+        product_name:
+          type: string
+          description: Display name of the product.
+          example: "WordPress File Upload"
+        product_name_premium:
+          type: string
+          nullable: true
+          description: Premium variant name when the author ships two plugins under the same slug. `null` in the common case.
+          example: null
+        product_type:
+          type: string
+          enum: [Plugin, Theme, WordPress]
+          description: Product ecosystem.
+          example: Plugin
+        vuln_type:
+          type: string
+          description: High-level vulnerability category (e.g. `SQL Injection`, `Cross Site Scripting (XSS)`).
+          example: Directory Traversal
+        cvss_score:
+          type: number
+          format: float
+          nullable: true
+          description: CVSS base score, 1.0–10.0. `null` for unclassified advisories.
+          example: 8.8
+        cve:
+          type: array
+          description: CVE identifiers. An advisory can have zero, one, or multiple.
+          items:
+            type: string
+          example: ["2021-24962"]
+        is_exploited:
+          type: boolean
+          description: Whether exploitation has been observed in the wild.
+          example: false
+        patch_priority:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: |
+            Recommended patch urgency.
+
+            - `1` — Low → patch within 30 days
+            - `2` — Medium → patch within 7 days
+            - `3+` — High → patch immediately
+            - `null` — unknown
+          example: 3
+        affected_in:
+          type: string
+          description: |
+            Affected version range. Formats include `<= x.x.x`, `< x.x.x`,
+            `x.x.x-x.x.x`, `x.x.x,x.x.x`, or a single `x.x.x`.
+          example: "<= 4.16.2"
+        fixed_in:
+          type: string
+          description: First fixed version. Empty string when Patchstack has not yet recorded one.
+          example: "4.16.3"
+        patched_in_ranges:
+          type: array
+          description: |
+            For products that ship patches across multiple minor lines
+            (WordPress core, WooCommerce, Ninja Forms, …), each entry
+            describes a `from_version`–`to_version` range and its fix.
+          items:
+            type: object
+            required: [from_version, to_version, fixed_in]
+            properties:
+              from_version:
+                type: string
+                description: Starting version, inclusive.
+                example: "3.0"
+              to_version:
+                type: string
+                description: Ending version, inclusive.
+                example: "3.0.34.1"
+              fixed_in:
+                type: string
+                description: Version that contains the patch for this range.
+                example: "3.0.34.2"
+        direct_url:
+          type: string
+          format: uri
+          description: Public Patchstack vulnerability page.
+          example: "https://patchstack.com/database/vulnerability/wp-file-upload/wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce"
+
+    BatchItem:
+      type: object
+      required: [name, version, type]
+      properties:
+        name:
+          type: string
+          description: Product slug (plugin/theme slug, or `wordpress`).
+          example: easy-digital-downloads1
+        version:
+          type: string
+          description: Concrete version.
+          example: "1.0.0"
+        type:
+          type: string
+          enum: [plugin, theme, wordpress]
+          example: plugin
+        exists:
+          type: boolean
+          description: When `true`, return a boolean-only result for this item.
+          example: true
+
+    VulnerabilityDetail:
+      type: object
+      description: Response shape for `GET /vulnerability/{id}`.
+      required: [vulnerability, product, type, cve, versions]
+      properties:
+        vulnerability:
+          type: object
+          required: [title, description, disclosed_at, created_at, is_exploited, url, direct_url]
+          properties:
+            title:
+              type: string
+              example: "WordPress Spam protection, AntiSpam, FireWall by CleanTalk plugin <= 5.153.3 - Unauthenticated Time-Based Blind SQL Injection (SQLi) vulnerability"
+            description:
+              type: string
+              example: "Unauthenticated Time-Based Blind SQL Injection (SQLi) vulnerability discovered by WordFence in WordPress Spam protection, AntiSpam, FireWall by CleanTalk plugin (versions <= 5.153.3)."
+            disclosure_date:
+              type: string
+              description: Disclosure date in `YYYY-MM-DD HH:MM:SS` form (legacy).
+              example: "2021-05-03 00:00:00"
+            disclosed_at:
+              type: string
+              format: date-time
+              example: "2021-05-03T00:00:00+00:00"
+            created_at:
+              type: string
+              format: date-time
+              example: "2021-09-28T14:17:02+00:00"
+            is_exploited:
+              type: boolean
+              example: true
+            url:
+              type: string
+              description: URL slug for the advisory.
+              example: wordpress-spam-protection-antispam-firewall-by-cleantalk-plugin-5-153-3-unauthenticated-time-based-blind-sql-injection-sqli-vulnerability
+            direct_url:
+              type: string
+              format: uri
+              example: "https://patchstack.com/database/vulnerability/cleantalk-spam-protect/wordpress-spam-protection-antispam-firewall-by-cleantalk-plugin-5-153-3-unauthenticated-time-based-blind-sql-injection-sqli-vulnerability"
+        product:
+          type: object
+          required: [name, slug, type]
+          properties:
+            name:
+              type: string
+              example: "Spam protection, AntiSpam, FireWall by CleanTalk"
+            slug:
+              type: string
+              example: cleantalk-spam-protect
+            type:
+              type: string
+              enum: [Plugin, Theme, WordPress]
+              example: Plugin
+        type:
+          type: string
+          description: Vulnerability category (e.g. `SQL Injection`).
+          example: SQL Injection
+        cvss:
+          type: object
+          nullable: true
+          properties:
+            score:
+              type: number
+              format: float
+              nullable: true
+              example: 7.5
+            vector:
+              type: string
+              nullable: true
+              example: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+            description:
+              type: string
+              nullable: true
+              example: ""
+        owasp:
+          type: string
+          description: "OWASP category (e.g. `A1: Injection`)."
+          example: "A1: Injection"
+        references_url:
+          type: array
+          description: External reference URLs with display titles.
+          items:
+            type: object
+            required: [url, title]
+            properties:
+              url:
+                type: string
+                format: uri
+                example: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24295"
+              title:
+                type: string
+                example: CVE
+        cve:
+          type: array
+          items:
+            type: string
+          example: ["2021-24295"]
+        versions:
+          type: object
+          required: [affected_in, fixed_in]
+          properties:
+            affected_in:
+              type: string
+              example: "<= 5.153.3"
+            fixed_in:
+              type: string
+              example: "5.153.4"
+        versions_list:
+          type: string
+          nullable: true
+          description: Comma-separated list of specific affected versions, when applicable.
+          example: null
+        credit:
+          type: object
+          nullable: true
+          description: Discoverer of the vulnerability.
+          properties:
+            name:
+              type: string
+              example: WordFence
+            url:
+              type: string
+              format: uri
+              example: "https://twitter.com/wordfence"
+        submitter:
+          type: object
+          nullable: true
+          description: Submitter, when distinct from `credit`.
+          properties:
+            name:
+              type: string
+              example: h00die
+            url:
+              type: string
+              format: uri
+              example: "https://packetstormsecurity.com/files/author/7166/"

--- a/public/schemas/threat-intel-standard.postman_collection.json
+++ b/public/schemas/threat-intel-standard.postman_collection.json
@@ -1,0 +1,741 @@
+{
+  "item": [
+    {
+      "name": "product/{type}/{name}/{version}",
+      "item": [
+        {
+          "name": "Find vulnerabilities for a product",
+          "request": {
+            "name": "Find vulnerabilities for a product",
+            "description": {
+              "content": "Return every advisory that applies to a specific WordPress plugin,\ntheme or core version.\n",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "product",
+                ":type",
+                ":name",
+                ":version"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "plugin",
+                  "key": "type",
+                  "description": "(Required) Product ecosystem."
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "tutor",
+                  "key": "name",
+                  "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "1.5.2",
+                  "key": "version",
+                  "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "name": "Matched advisories (possibly empty).",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"vulnerabilities\": [\n    {\n      \"id\": 4253,\n      \"title\": \"WordPress Tutor LMS plugin <= 1.5.2 - Cross-Site Request Forgery (CSRF) vulnerability\",\n      \"disclosed_at\": \"2020-02-04T00:00:00+00:00\",\n      \"created_at\": \"2022-05-27T10:23:01+00:00\",\n      \"product_slug\": \"tutor\",\n      \"product_name\": \"Tutor LMS\",\n      \"product_name_premium\": null,\n      \"product_type\": \"Plugin\",\n      \"fixed_in\": \"1.5.3\",\n      \"direct_url\": \"https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-5-2-cross-site-request-forgery-csrf-vulnerability\"\n    }\n  ]\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "name": "Missing or invalid `PSKey` header.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "API key not authorised for the requested endpoint.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "Unknown product/version combination.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Not Found",
+              "code": 404,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "Rate limit exceeded (5,000 requests / 24 hours).",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "name": "Boolean exists check for a product",
+          "request": {
+            "name": "Boolean exists check for a product",
+            "description": {
+              "content": "Boolean-only variant of the product lookup. Returns\n`{ \"vulnerable\": true }` or `{ \"vulnerable\": false }` without the\nadvisory payload — useful for lightweight checks and dashboard tiles\nwhere the advisory body isn't needed.\n",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "product",
+                ":type",
+                ":name",
+                ":version",
+                "exists"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "plugin",
+                  "key": "type",
+                  "description": "(Required) Product ecosystem."
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "tutor",
+                  "key": "name",
+                  "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                },
+                {
+                  "disabled": false,
+                  "type": "any",
+                  "value": "1.5.2",
+                  "key": "version",
+                  "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "name": "Boolean result.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  },
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"vulnerable\": true\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "name": "Missing or invalid `PSKey` header.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "API key not authorised for the requested endpoint.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Forbidden",
+              "code": 403,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "name": "Rate limit exceeded (5,000 requests / 24 hours).",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "product",
+                    ":type",
+                    ":name",
+                    ":version",
+                    "exists"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "plugin",
+                      "key": "type",
+                      "description": "(Required) Product ecosystem."
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "tutor",
+                      "key": "name",
+                      "description": "(Required) WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.\nSlugs are lowercase — normalize your own data before comparison.\n"
+                    },
+                    {
+                      "disabled": false,
+                      "type": "any",
+                      "value": "1.5.2",
+                      "key": "version",
+                      "description": "(Required) Concrete version (e.g. `1.5.2`)."
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": {
+                      "content": "Added as a part of security scheme: apikey",
+                      "type": "text/plain"
+                    },
+                    "key": "PSKey",
+                    "value": "<API Key>"
+                  }
+                ],
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": [],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "https://patchstack.com/database/api/v2",
+      "key": "baseUrl"
+    }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "key",
+        "value": "PSKey"
+      },
+      {
+        "key": "value",
+        "value": "{{apiKey}}"
+      },
+      {
+        "key": "in",
+        "value": "header"
+      }
+    ]
+  },
+  "info": {
+    "name": "Patchstack Threat Intelligence API — Standard",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "The Standard Threat Intelligence API returns vulnerability information for\na single WordPress plugin, theme or core version. It's the entry-level tier\nof the v2 API — if you need bulk lookups, the latest-24h feed, or by-id\nadvisory lookup, use the [Extended tier](/api-solutions/threat-intelligence-api/extended/)\ninstead.\n\n## Authentication\n\nEvery request must include your API key in the `PSKey` HTTP request header.\nRequest a key via your [Patchstack App billing page](https://app.patchstack.com/billing/subscription).\n\n## Rate limiting\n\nStandard is limited to **5,000 requests per 24 hours**. Contact\n<https://patchstack.com/for-hosts/> if you need an elevated quota or the\nExtended tier.\n\n## Caching\n\nResponses are JSON and cached until the Patchstack database updates, at\nwhich point the appropriate caches are cleared.\n\n## Errors\n\n| Status | Meaning |\n|---|---|\n| `401` | Missing or invalid `PSKey` header. |\n| `403` | API key not authorised for the requested endpoint. |\n| `404` | Unknown product/version combination. |\n| `429` | Rate limit exceeded. |\n| `500` | Server error — include the request id in any bug report. |\n\n## Related pages\n\n- Narrative guide with code samples: [Standard tier API](/api-solutions/threat-intelligence-api/standard/)\n- Field glossary: [API properties](/api-solutions/threat-intelligence-api/api-properties/)\n- OpenAPI spec (import into Postman / Insomnia / Bruno / Hoppscotch): <https://docs.patchstack.com/schemas/threat-intel-standard.yaml>\n- Postman collection (pre-imported): <https://docs.patchstack.com/schemas/threat-intel-standard.postman_collection.json>\n\nIntegration questions: <dave.jong@patchstack.com>.\n\n\nContact Support:\n Name: Patchstack\n Email: dave.jong@patchstack.com",
+      "type": "text/plain"
+    }
+  }
+}

--- a/public/schemas/threat-intel-standard.yaml
+++ b/public/schemas/threat-intel-standard.yaml
@@ -1,0 +1,261 @@
+openapi: 3.1.0
+info:
+  title: Patchstack Threat Intelligence API — Standard
+  version: v2
+  summary: WordPress plugin, theme and core vulnerability lookups for a single product + version.
+  description: |
+    The Standard Threat Intelligence API returns vulnerability information for
+    a single WordPress plugin, theme or core version. It's the entry-level tier
+    of the v2 API — if you need bulk lookups, the latest-24h feed, or by-id
+    advisory lookup, use the [Extended tier](/api-solutions/threat-intelligence-api/extended/)
+    instead.
+
+    ## Authentication
+
+    Every request must include your API key in the `PSKey` HTTP request header.
+    Request a key via your [Patchstack App billing page](https://app.patchstack.com/billing/subscription).
+
+    ## Rate limiting
+
+    Standard is limited to **5,000 requests per 24 hours**. Contact
+    <https://patchstack.com/for-hosts/> if you need an elevated quota or the
+    Extended tier.
+
+    ## Caching
+
+    Responses are JSON and cached until the Patchstack database updates, at
+    which point the appropriate caches are cleared.
+
+    ## Errors
+
+    | Status | Meaning |
+    |---|---|
+    | `401` | Missing or invalid `PSKey` header. |
+    | `403` | API key not authorised for the requested endpoint. |
+    | `404` | Unknown product/version combination. |
+    | `429` | Rate limit exceeded. |
+    | `500` | Server error — include the request id in any bug report. |
+
+    ## Related pages
+
+    - Narrative guide with code samples: [Standard tier API](/api-solutions/threat-intelligence-api/standard/)
+    - Field glossary: [API properties](/api-solutions/threat-intelligence-api/api-properties/)
+    - OpenAPI spec (import into Postman / Insomnia / Bruno / Hoppscotch): <https://docs.patchstack.com/schemas/threat-intel-standard.yaml>
+    - Postman collection (pre-imported): <https://docs.patchstack.com/schemas/threat-intel-standard.postman_collection.json>
+
+    Integration questions: <dave.jong@patchstack.com>.
+  contact:
+    name: Patchstack
+    url: https://patchstack.com/for-hosts/
+    email: dave.jong@patchstack.com
+
+servers:
+  - url: https://patchstack.com/database/api/v2
+    description: Production
+
+security:
+  - PSKey: []
+
+tags:
+  - name: Products
+    description: |
+      Match a specific WordPress plugin, theme or core version against the
+      vulnerability database and return every applicable advisory.
+
+      - [`GET /product/{type}/{name}/{version}`](/api-reference/threat-intelligence-standard/operations/findproductvulnerabilities/)
+        — full advisory list for the product.
+      - [`GET /product/{type}/{name}/{version}/exists`](/api-reference/threat-intelligence-standard/operations/productvulnerabilityexists/)
+        — boolean-only variant for fast "is this vulnerable?" checks.
+
+      `type` accepts `plugin`, `theme`, or `wordpress`. When `type=wordpress`
+      pass `wordpress` as the `name`.
+
+paths:
+  /product/{type}/{name}/{version}:
+    get:
+      tags: [Products]
+      summary: Find vulnerabilities for a product
+      description: |
+        Return every advisory that applies to a specific WordPress plugin,
+        theme or core version.
+      operationId: findProductVulnerabilities
+      parameters:
+        - $ref: '#/components/parameters/ProductType'
+        - $ref: '#/components/parameters/ProductName'
+        - $ref: '#/components/parameters/ProductVersion'
+      responses:
+        '200':
+          description: Matched advisories (possibly empty).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [vulnerabilities]
+                properties:
+                  vulnerabilities:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StandardVulnerability'
+              example:
+                vulnerabilities:
+                  - id: 4253
+                    title: "WordPress Tutor LMS plugin <= 1.5.2 - Cross-Site Request Forgery (CSRF) vulnerability"
+                    disclosed_at: "2020-02-04T00:00:00+00:00"
+                    created_at: "2022-05-27T10:23:01+00:00"
+                    product_slug: tutor
+                    product_name: "Tutor LMS"
+                    product_name_premium: null
+                    product_type: Plugin
+                    fixed_in: "1.5.3"
+                    direct_url: "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-5-2-cross-site-request-forgery-csrf-vulnerability"
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /product/{type}/{name}/{version}/exists:
+    get:
+      tags: [Products]
+      summary: Boolean exists check for a product
+      description: |
+        Boolean-only variant of the product lookup. Returns
+        `{ "vulnerable": true }` or `{ "vulnerable": false }` without the
+        advisory payload — useful for lightweight checks and dashboard tiles
+        where the advisory body isn't needed.
+      operationId: productVulnerabilityExists
+      parameters:
+        - $ref: '#/components/parameters/ProductType'
+        - $ref: '#/components/parameters/ProductName'
+        - $ref: '#/components/parameters/ProductVersion'
+      responses:
+        '200':
+          description: Boolean result.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [vulnerable]
+                properties:
+                  vulnerable:
+                    type: boolean
+              example:
+                vulnerable: true
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+components:
+  securitySchemes:
+    PSKey:
+      type: apiKey
+      in: header
+      name: PSKey
+      description: |
+        API key issued by Patchstack. Request one from your
+        [Patchstack App billing page](https://app.patchstack.com/billing/subscription).
+
+  parameters:
+    ProductType:
+      name: type
+      in: path
+      required: true
+      description: Product ecosystem.
+      schema:
+        type: string
+        enum: [plugin, theme, wordpress]
+        example: plugin
+    ProductName:
+      name: name
+      in: path
+      required: true
+      description: |
+        WordPress plugin or theme slug. Use `wordpress` when `type=wordpress`.
+        Slugs are lowercase — normalize your own data before comparison.
+      schema:
+        type: string
+        example: tutor
+    ProductVersion:
+      name: version
+      in: path
+      required: true
+      description: Concrete version (e.g. `1.5.2`).
+      schema:
+        type: string
+        example: "1.5.2"
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid `PSKey` header.
+    Forbidden:
+      description: API key not authorised for the requested endpoint.
+    NotFound:
+      description: Unknown product/version combination.
+    TooManyRequests:
+      description: Rate limit exceeded (5,000 requests / 24 hours).
+
+  schemas:
+    StandardVulnerability:
+      type: object
+      description: |
+        Flat per-item shape returned by the Standard tier. For the richer shape
+        (with `description`, `cvss_score`, `cve`, `patched_in_ranges`, etc.),
+        see the [Extended tier](/api-reference/threat-intelligence-extended/).
+      required:
+        - id
+        - title
+        - disclosed_at
+        - created_at
+        - product_slug
+        - product_name
+        - product_type
+        - fixed_in
+        - direct_url
+      properties:
+        id:
+          type: integer
+          description: Stable Patchstack vulnerability id.
+          example: 4253
+        title:
+          type: string
+          description: Human-readable title including product name, affected version, and vulnerability type.
+          example: "WordPress Tutor LMS plugin <= 1.5.2 - Cross-Site Request Forgery (CSRF) vulnerability"
+        disclosed_at:
+          type: string
+          format: date-time
+          description: When the vulnerability was publicly disclosed (ISO 8601).
+          example: "2020-02-04T00:00:00+00:00"
+        created_at:
+          type: string
+          format: date-time
+          description: When the row was inserted into the Patchstack database (ISO 8601).
+          example: "2022-05-27T10:23:01+00:00"
+        product_slug:
+          type: string
+          description: Lowercase slug of the product.
+          example: tutor
+        product_name:
+          type: string
+          description: Display name of the product.
+          example: "Tutor LMS"
+        product_name_premium:
+          type: string
+          nullable: true
+          description: |
+            Premium variant name when a plugin author ships two plugins under
+            the same slug. `null` in the common case.
+        product_type:
+          type: string
+          enum: [Plugin, Theme, WordPress]
+          description: Product ecosystem.
+          example: Plugin
+        fixed_in:
+          type: string
+          description: |
+            First version that contains the patch. Empty string when Patchstack
+            has not yet recorded a fixed version.
+          example: "1.5.3"
+        direct_url:
+          type: string
+          format: uri
+          description: Public Patchstack vulnerability page.
+          example: "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-5-2-cross-site-request-forgery-csrf-vulnerability"

--- a/src/content/docs/API solutions/Threat Intelligence API/beta.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/beta.md
@@ -14,49 +14,10 @@ sidebar:
 _The Npm Dataset API (Beta) is a new generation of the Threat Intelligence API, currently available to **selected partners working directly with Patchstack**. It lives alongside the v2 API (Standard / Extended) and adds npm coverage, an optional full advisory body, a consistent nested response shape, and cursor pagination. If you'd like access to run an integration on Beta, [contact us](https://patchstack.com/for-hosts/)._
 
 > **Interactive reference:** Every endpoint, parameter, request body and response shape is documented in the [Threat Intelligence API (Beta) reference](/api-reference/threat-intelligence-beta/).
+>
+> **Tooling (Postman, SDK, LLM):** spec URLs and import instructions for all three tiers live on [Overview → Using the APIs with your tools](/api-solutions/threat-intelligence-api/overview/#using-the-apis-with-your-tools).
 
 This page covers the concepts you need to use the API effectively — authentication, platforms, pagination, rate limiting, and migration from v2. Use it alongside the interactive reference.
-
-## Use with Postman, Insomnia, Bruno or Hoppscotch
-
-We publish the API as an [OpenAPI 3.1 spec](https://docs.patchstack.com/schemas/threat-intel-beta.yaml) and a pre-built [Postman collection](https://docs.patchstack.com/schemas/threat-intel-beta.postman_collection.json). Every endpoint, parameter, request body and example is preconfigured — set your `PSKey` once and the whole collection authenticates.
-
-[Download the collection](/schemas/threat-intel-beta.postman_collection.json) and drag it into Postman/Insomnia/Bruno/Hoppscotch, or import it by URL from inside the tool.
-
-| Tool | How to import |
-|---|---|
-| **Postman** | `File → Import → Link` and paste the collection URL. |
-| **Insomnia** | `Create → Import From → URL` → paste the OpenAPI URL. |
-| **Bruno** | `Collection → Import → OpenAPI V3 Spec` → paste the OpenAPI URL. |
-| **Hoppscotch** | `Collections → Import/Export → OpenAPI` → paste the OpenAPI URL. |
-
-**Authentication:** in Postman set the collection `Authorization` to **API Key**, key `PSKey`, value `{{PSKEY}}`, and add `PSKEY` as a collection variable with your real key as the **Current value** (leave Initial blank so it doesn't sync to teammates). Other tools work the same way — set `PSKey` as a collection header once.
-
-## Use with Claude Code or other LLM coding assistants
-
-Point your assistant at the spec. LLMs parse OpenAPI cleanly and will generate clients that match the real field names instead of hallucinating.
-
-- **Ad hoc:** paste the spec URL into your prompt. Example: *"Write a Python client for `https://docs.patchstack.com/schemas/threat-intel-beta.yaml`. I need cursor-mode iteration over `/all` for npm."*
-- **In your repo:** download the spec to `docs/vendor/patchstack-threat-intel-beta.yaml` and reference it from your `CLAUDE.md` / `AGENTS.md`. Your assistant can then grep the YAML for specific fields without refetching.
-- **Plain-text fallback:** for tools that don't parse YAML, our [`llms-full.txt`](/llms-full.txt) contains the full reference as flat markdown.
-
-## SDK generation
-
-Generate a client in any language from the same spec:
-
-```bash
-# TypeScript
-npx @openapitools/openapi-generator-cli generate \
-  -i https://docs.patchstack.com/schemas/threat-intel-beta.yaml \
-  -g typescript-fetch -o ./patchstack-client
-
-# Python
-npx @openapitools/openapi-generator-cli generate \
-  -i https://docs.patchstack.com/schemas/threat-intel-beta.yaml \
-  -g python -o ./patchstack-client-py
-```
-
-Speakeasy and Fern also consume the same spec and produce more idiomatic SDKs if you need a polished client library.
 
 > **Spec stability:** the Beta spec may change without a version bump while the API is in beta. Pin a commit of the YAML in production integrations, or wait for the GA release when we'll publish versioned URLs.
 
@@ -145,10 +106,6 @@ curl 'https://patchstack.com/database/api/beta/product/npm/axios/0.21.4?include=
 curl 'https://patchstack.com/database/api/beta/product/npm/axios/0.21.4/exists' \
   -H 'PSKey: <your-api-key>'
 ```
-
-### Postman / Insomnia / Bruno / Hoppscotch
-
-Import the OpenAPI spec directly from [`threat-intel-beta.yaml`](https://docs.patchstack.com/schemas/threat-intel-beta.yaml) — authentication, parameters and example payloads are preconfigured. Set the `PSKey` security value to your API key once and every request in the collection will use it.
 
 ### Cursor iteration (JavaScript / Node)
 

--- a/src/content/docs/API solutions/Threat Intelligence API/extended.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/extended.md
@@ -1,541 +1,182 @@
 ---
 title: "Extended tier API"
-excerpt: ""
+excerpt: "WordPress vulnerability intelligence with bulk lookups, latest-24h feed, and advisory-by-id details."
 hidden: false
-metadata: 
+metadata:
   image: []
   robots: "index"
 createdAt: "Mon Jul 25 2022 09:29:10 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Thu Jun 15 2023 11:25:44 GMT+0000 (Coordinated Universal Time)"
 sidebar:
   order: 2
+  label: "Guide"
 ---
 
-_The purpose of this document is to provide information about the Extended Threat Intelligence API functionality._
+_The Extended Threat Intelligence API is a superset of the [Standard tier](/api-solutions/threat-intelligence-api/standard/). Extended has **custom pricing and is activated on request** — [contact us](https://patchstack.com/for-hosts/)._
 
-## API Usage
+> **Interactive reference:** Every endpoint, parameter, request body and response shape is documented in the [Threat Intelligence API (Extended) reference](/api-reference/threat-intelligence-extended/).
 
-### Information
+This page covers the concepts you need to use the API effectively — authentication, rate limiting, errors, and code samples. Use it alongside the interactive reference.
 
-The base URL of the API is <https://patchstack.com/database/api/v2/>
+## What Extended adds over Standard
 
-All responses are in the JSON format. For performance reasons, responses are cached until we update the database after which the appropriate caches are cleared.
+| | Standard | Extended |
+|---|---|---|
+| Per-item payload | Flat, minimal | Flat, includes `description`, `vuln_type`, `cvss_score`, `cve`, `is_exploited`, `patch_priority`, `affected_in`, `patched_in_ranges` |
+| `GET /product/{type}/{name}/{version}` | ✓ | ✓ |
+| `GET /product/{type}/{name}/{version}/exists` | ✓ | ✓ |
+| `GET /latest` — 20 most recent | — | ✓ |
+| `POST /batch` — up to 50 products per request | — | ✓ |
+| `GET /vulnerability/{id}` — advisory detail (CVSS vector, OWASP, references, credit) | — | ✓ |
+| Rate limit | 5,000 / 24h | Custom, set per contract |
 
-An API key is required. This API key should be present in the **PSKey HTTP request header**. You can request an API key by reaching out to us on this page: <a href="https://patchstack.com/for-hosts/" target="_blank">https:<span></span>//patchstack.com/for-hosts/</a>
+## Use with Postman, Insomnia, Bruno or Hoppscotch
 
-Explanation of the API response properties can be found here [here](/api-solutions/threat-intelligence-api/api-properties/).
+We publish the API as an [OpenAPI 3.1 spec](https://docs.patchstack.com/schemas/threat-intel-extended.yaml) and a pre-built [Postman collection](https://docs.patchstack.com/schemas/threat-intel-extended.postman_collection.json). Every endpoint, parameter, request body and example is preconfigured — set your `PSKey` once and the whole collection authenticates.
 
-### Latest vulnerabilities
+[Download the collection](/schemas/threat-intel-extended.postman_collection.json) and drag it into Postman/Insomnia/Bruno/Hoppscotch, or import it by URL from inside the tool.
 
-**Description:** Retrieve the latest 20 vulnerabilities which have been added to the database.  
-**Endpoint:** /latest  
-**Method:** GET
+| Tool | How to import |
+|---|---|
+| **Postman** | `File → Import → Link` and paste the collection URL. |
+| **Insomnia** | `Create → Import From → URL` → paste the OpenAPI URL. |
+| **Bruno** | `Collection → Import → OpenAPI V3 Spec` → paste the OpenAPI URL. |
+| **Hoppscotch** | `Collections → Import/Export → OpenAPI` → paste the OpenAPI URL. |
 
-**Example response (trimmed)** <https://patchstack.com/database/api/v2/latest>
+**Authentication:** in Postman set the collection `Authorization` to **API Key**, key `PSKey`, value `{{PSKEY}}`, and add `PSKEY` as a collection variable with your real key as the **Current value** (leave Initial blank so it doesn't sync to teammates). Other tools work the same way — set `PSKey` as a collection header once.
 
-```json
-{
-    "vulnerabilities": [
-        {
-            "id": 7976,
-            "product_id": 2175,
-            "title": "WordPress File Upload plugin <= 4.16.2 - Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE)",
-            "description": "Contributor+ Path Traversal vulnerability leading to Remote Code Execution (RCE) discovered by apple502j in WordPress File Upload plugin (versions <= 4.16.2).",
-            "disclosure_date": "2022-03-01 00:00:00",
-            "disclosed_at": "2022-03-01T00:00:00+00:00",
-            "created_at": "2022-03-07T11:17:05+00:00",
-            "url": "wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce",
-            "product_slug": "wp-file-upload",
-            "product_name": "WordPress File Upload",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Directory Traversal",
-            "cvss_score": 8.8,
-            "cve": [
-                "2021-24962"
-            ],
-            "is_exploited": false,
-            "patch_priority": 3,
-            "affected_in": "<= 4.16.2",
-            "fixed_in": "4.16.3",
-            "patched_in_ranges": [],
-            "direct_url": "https://patchstack.com/database/vulnerability/wp-file-upload/wordpress-file-upload-plugin-4-16-2-contributor-path-traversal-vulnerability-leading-to-remote-code-execution-rce"
-        },
-        {
-            "id": 7957,
-            "product_id": 3808,
-            "title": "WordPress All in One Invite Codes plugin <= 1.0.12 - Sensitive Information Disclosure vulnerability",
-            "description": "Sensitive Information Disclosure vulnerability discovered in WordPress All in One Invite Codes plugin (versions <= 1.0.12).",
-            "disclosure_date": "2022-02-28 00:00:00",
-            "disclosed_at": "2022-02-28T00:00:00+00:00",
-            "created_at": "2022-03-03T13:25:05+00:00",
-            "url": "wordpress-all-in-one-invite-codes-plugin-1012-sensitive-information-disclosure-vulnerability",
-            "product_slug": "all-in-one-invite-codes",
-            "product_name": "All in One Invite Codes",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Information Disclosure",
-            "cvss_score": 4.3,
-            "cve": [],
-            "is_exploited": false,
-            "patch_priority": 1,
-            "affected_in": "<= 1.0.12",
-            "fixed_in": "",
-            "patched_in_ranges": [],
-            "direct_url": "https://patchstack.com/database/vulnerability/all-in-one-invite-codes/wordpress-all-in-one-invite-codes-plugin-1012-sensitive-information-disclosure-vulnerability"
-        }
-    ]
-}
+## Use with Claude Code or other LLM coding assistants
+
+Point your assistant at the spec. LLMs parse OpenAPI cleanly and will generate clients that match the real field names instead of hallucinating.
+
+- **Ad hoc:** paste the spec URL into your prompt. Example: *"Write a Node script that walks `POST /batch` over a `package.json`-style list of plugins using `https://docs.patchstack.com/schemas/threat-intel-extended.yaml`."*
+- **In your repo:** download the spec to `docs/vendor/patchstack-threat-intel-extended.yaml` and reference it from your `CLAUDE.md` / `AGENTS.md`. Your assistant can then grep the YAML for specific fields without refetching.
+- **Plain-text fallback:** for tools that don't parse YAML, our [`llms-full.txt`](/llms-full.txt) contains the full reference as flat markdown.
+
+## SDK generation
+
+Generate a client in any language from the same spec:
+
+```bash
+# TypeScript
+npx @openapitools/openapi-generator-cli generate \
+  -i https://docs.patchstack.com/schemas/threat-intel-extended.yaml \
+  -g typescript-fetch -o ./patchstack-client
+
+# Python
+npx @openapitools/openapi-generator-cli generate \
+  -i https://docs.patchstack.com/schemas/threat-intel-extended.yaml \
+  -g python -o ./patchstack-client-py
 ```
 
-### Find vulnerability
+Speakeasy and Fern also consume the same spec and produce more idiomatic SDKs if you need a polished client library.
 
-**Description:** Retrieve vulnerabilities of a specific plugin, theme or WordPress core version.  
-**Endpoint:** /product/TYPE/NAME/VERSION/EXISTS?  
-**Method:** GET
+## Base URL
 
-**TYPE** = theme, plugin, wordpress  
-**NAME** = Slug of the theme, slug of the plugin, or “wordpress” in case TYPE is set to wordpress  
-**VERSION** = Version to check for vulnerabilities  
-**EXISTS** = Optional flag that will not return all vulnerabilities but only a boolean response whether or not there are vulnerabilities. This flag being present results in a faster response.
-
-**Example Response** <https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2>    
-
-```json
-{
-    "vulnerabilities": [
-        {
-            "id": 4253,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.5.2 - Cross-Site Request Forgery (CSRF) vulnerability",
-            "description": "Cross-Site Request Forgery (CSRF) vulnerability found by Jinson Varghese Behanan in WordPress Tutor LMS plugin (versions <= 1.5.2).",
-            "disclosure_date": "2020-02-04 00:00:00",
-            "disclosed_at": "2020-02-04T00:00:00+00:00",
-            "created_at": "2021-01-08T13:50:05+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-5-2-cross-site-request-forgery-csrf-vulnerability",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Cross Site Request Forgery (CSRF)",
-            "cvss_score": null,
-            "cve": [
-                "2020-8615"
-            ],
-            "is_exploited": false,
-            "patch_priority": 1,
-            "affected_in": "<= 1.5.2",
-            "fixed_in": "1.5.3",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-5-2-cross-site-request-forgery-csrf-vulnerability"
-        },
-        {
-            "id": 4386,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.7.6 - Multiple Blind/Time-based SQL Injection (SQLi) vulnerabilities",
-            "description": "Multiple Blind/Time-based SQL Injection (SQLi) vulnerabilities were discovered by WordFence in the WordPress Tutor LMS plugin (versions <= 1.7.6).",
-            "disclosure_date": "2021-03-15 00:00:00",
-            "disclosed_at": "2021-03-15T00:00:00+00:00",
-            "created_at": "2021-06-07T10:12:03+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-7-6-multiple-blind-time-based-sql-injection-sqli-vulnerabilities",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "SQL Injection",
-            "cvss_score": 5.4,
-            "cve": [],
-            "is_exploited": false,
-            "patch_priority": 2,
-            "affected_in": "<= 1.7.6",
-            "fixed_in": "1.7.7",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-7-6-multiple-blind-time-based-sql-injection-sqli-vulnerabilities"
-        },
-        {
-            "id": 4387,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.8.2 - Multiple Union SQL Injection (SQLi) vulnerabilities",
-            "description": "Multiple Union SQL Injection (SQLi) vulnerabilities were discovered by WordFence in the WordPress Tutor LMS plugin (versions <= 1.8.2).",
-            "disclosure_date": "2021-03-15 00:00:00",
-            "disclosed_at": "2021-03-15T00:00:00+00:00",
-            "created_at": "2021-03-16T08:48:03+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-8-2-multiple-union-sql-injection-sqli-vulnerabilities",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "SQL Injection",
-            "cvss_score": null,
-            "cve": [],
-            "is_exploited": false,
-            "patch_priority": 2,
-            "affected_in": "<= 1.8.2",
-            "fixed_in": "1.8.3",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-8-2-multiple-union-sql-injection-sqli-vulnerabilities"
-        },
-        {
-            "id": 4388,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.7.6 - Unprotected AJAX Action to Privilege Escalation vulnerability",
-            "description": "Unprotected AJAX Action to Privilege Escalation vulnerability discovered by WordFence in WordPress Tutor LMS plugin (versions <= 1.7.6).",
-            "disclosure_date": "2021-03-15 00:00:00",
-            "disclosed_at": "2021-03-15T00:00:00+00:00",
-            "created_at": "2021-08-31T08:00:05+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-7-6-unprotected-ajax-action-to-privilege-escalation-vulnerability",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Privilege Escalation",
-            "cvss_score": null,
-            "cve": [],
-            "is_exploited": false,
-            "patch_priority": 3,
-            "affected_in": "<= 1.7.6",
-            "fixed_in": "1.7.7",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-7-6-unprotected-ajax-action-to-privilege-escalation-vulnerability"
-        },
-        {
-            "id": 4549,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.8.7 - Authenticated Local File Inclusion vulnerability",
-            "description": "Authenticated Local File Inclusion vulnerability discovered by sasa in WordPress Tutor LMS plugin (versions <= 1.8.7)",
-            "disclosure_date": "2021-04-05 00:00:00",
-            "disclosed_at": "2021-04-05T00:00:00+00:00",
-            "created_at": "2021-04-19T09:28:03+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-8-7-authenticated-local-file-inclusion-vulnerability",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Local File Inclusion",
-            "cvss_score": 4.9,
-            "cve": [
-                "2021-24242"
-            ],
-            "is_exploited": false,
-            "patch_priority": 1,
-            "affected_in": "<= 1.8.7",
-            "fixed_in": "1.8.8",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-8-7-authenticated-local-file-inclusion-vulnerability"
-        },
-        {
-            "id": 5082,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.9.5 - Reflected Cross-Site Scripting (XSS) vulnerability",
-            "description": "Reflected Cross-Site Scripting (XSS) vulnerability discovered by WPScanTeam in WordPress Tutor LMS plugin (versions <= 1.9.5).",
-            "disclosure_date": "2021-08-09 00:00:00",
-            "disclosed_at": "2021-08-09T00:00:00+00:00",
-            "created_at": "2021-08-20T06:35:01+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-9-5-reflected-cross-site-scripting-xss-vulnerability",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Cross Site Scripting (XSS)",
-            "cvss_score": 7.1,
-            "cve": [],
-            "is_exploited": false,
-            "patch_priority": 2,
-            "affected_in": "<= 1.9.5",
-            "fixed_in": "1.9.6",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-9-5-reflected-cross-site-scripting-xss-vulnerability"
-        },
-        {
-            "id": 5388,
-            "product_id": 2642,
-            "title": "WordPress Tutor LMS plugin <= 1.9.8 - Multiple Stored Cross-Site Scripting (XSS) vulnerabilities",
-            "description": "Multiple Stored Cross-Site Scripting (XSS) vulnerabilities were discovered by Shivam Rai in the WordPress Tutor LMS plugin (versions <= 1.9.8).",
-            "disclosure_date": "2021-09-20 00:00:00",
-            "disclosed_at": "2021-09-20T00:00:00+00:00",
-            "created_at": "2021-10-22T12:54:01+00:00",
-            "url": "wordpress-tutor-lms-plugin-1-9-8-multiple-stored-cross-site-scripting-xss-vulnerabilities",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "vuln_type": "Cross Site Scripting (XSS)",
-            "cvss_score": 6.9,
-            "cve": [
-                "2021-24740"
-            ],
-            "is_exploited": false,
-            "patch_priority": 2,
-            "affected_in": "<= 1.9.8",
-            "fixed_in": "1.9.9",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-9-8-multiple-stored-cross-site-scripting-xss-vulnerabilities"
-        }
-    ]
-}
+```
+https://patchstack.com/database/api/v2/
 ```
 
-**Example Response** <https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2/exists>    
+## Authentication
 
-```json
-{
-	"vulnerable": true
-}
+Every request must include your API key in the **`PSKey`** HTTP request header. Extended access is activated on request — [contact us](https://patchstack.com/for-hosts/) to request a key.
+
+```
+PSKey: <your-api-key>
 ```
 
-### Bulk find vulnerability
+## Response format
 
-**Description:** Retrieve vulnerabilities in bulk of a number of plugins, themes or WordPress versions.  
-**Endpoint:** /batch  
-**Method:** POST  
-**Payload:** Raw JSON payload, same format as the individual vulnerability endpoint. This payload should contain no more than 50 objects.
+All responses are JSON. Responses are cached until the Patchstack database updates, at which point the cache is cleared.
 
-**Payload Example 1**
+Extended returns a **flat** per-item shape with more fields than Standard — see the [API properties](/api-solutions/threat-intelligence-api/api-properties/) glossary for field definitions. `GET /vulnerability/{id}` returns a richer, differently-shaped payload documented in the [reference](/api-reference/threat-intelligence-extended/).
 
-This payload example will determine if WooCommerce version 3.0.0 has vulnerabilities and if WordPress version 3.0.0 has vulnerabilities. It will also only return a boolean response.
+## Batch lookups
 
-```json
-[
-	{"name":"easy-digital-downloads1","version":"1.0.0","type":"plugin","exists":true},
-	{"name":"wordpress","version":"3.0.0","type":"wordpress","exists":true}
-]
+`POST /batch` accepts an array of up to 50 `{name, version, type, exists?}` items. The response is keyed by `product_slug`, not by array index — duplicate slugs in the request collapse. Per-item `exists: true` returns a boolean for that slug; `exists: false` (or omitted) returns the full advisory list.
+
+## Rate limiting
+
+Custom, set per contract. Contact <https://patchstack.com/for-hosts/> if you need a quota change.
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `401 Unauthorized` | Missing or invalid `PSKey` header. |
+| `403 Forbidden` | API key not authorised for the requested endpoint. |
+| `404 Not Found` | Unknown product/version or vulnerability id. |
+| `422 Unprocessable Entity` | Invalid request payload (e.g. batch with more than 50 items). |
+| `429 Too Many Requests` | Rate limit exceeded. |
+| `500` | Server error — please include the request id in any bug report. |
+
+---
+
+## Testing
+
+### curl — one-liners
+
+```bash
+# Latest 20 vulnerabilities
+curl 'https://patchstack.com/database/api/v2/latest' \
+  -H 'PSKey: <your-api-key>'
+
+# Full advisory list for a plugin version
+curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2' \
+  -H 'PSKey: <your-api-key>'
+
+# Boolean-only exists check
+curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2/exists' \
+  -H 'PSKey: <your-api-key>'
+
+# Batch — boolean-only across three products
+curl -X POST 'https://patchstack.com/database/api/v2/batch' \
+  -H 'PSKey: <your-api-key>' \
+  -H 'Content-Type: application/json' \
+  -d '[
+    {"name":"easy-digital-downloads1","version":"1.0.0","type":"plugin","exists":true},
+    {"name":"wordpress","version":"3.0.0","type":"wordpress","exists":true}
+  ]'
+
+# Advisory detail by id
+curl 'https://patchstack.com/database/api/v2/vulnerability/4760' \
+  -H 'PSKey: <your-api-key>'
 ```
 
-**Example response 1** <https://patchstack.com/database/api/v2/batch>
+### Batch walk (PHP)
 
-```json
-{
-    "vulnerabilities": {
-        "easy-digital-downloads1": true,
-        "wordpress": true
+```php
+<?php
+
+$apiKey = getenv('PATCHSTACK_KEY');
+$components = [
+    ['name' => 'easy-digital-downloads1', 'version' => '1.0.0', 'type' => 'plugin',    'exists' => false],
+    ['name' => 'wordpress',               'version' => '3.0.0', 'type' => 'wordpress', 'exists' => true],
+];
+
+$ch = curl_init('https://patchstack.com/database/api/v2/batch');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_HTTPHEADER     => ['PSKey: '.$apiKey, 'Content-Type: application/json'],
+    CURLOPT_POSTFIELDS     => json_encode($components),
+]);
+$response = json_decode(curl_exec($ch), true);
+curl_close($ch);
+
+foreach ($response['vulnerabilities'] as $slug => $result) {
+    if (is_bool($result)) {
+        echo "{$slug}: ".($result ? 'vulnerable' : 'clear').PHP_EOL;
+    } else {
+        echo "{$slug}: ".count($result)." advisor".(count($result) === 1 ? 'y' : 'ies').PHP_EOL;
     }
 }
 ```
 
-**Payload example 2**
+### Postman / Insomnia / Bruno / Hoppscotch
 
-This payload example will determine if WooCommerce version 3.0.0 has vulnerabilities and if WordPress version 3.0.0 has vulnerabilities. For WooCommerce it will return all vulnerabilities and for WordPress if it will return a boolean response.
+Import the OpenAPI spec directly from [`threat-intel-extended.yaml`](https://docs.patchstack.com/schemas/threat-intel-extended.yaml) — authentication, parameters and example payloads are preconfigured. Set the `PSKey` security value to your API key once and every request in the collection will use it.
 
-```json
-[
-	{"name":"easy-digital-downloads1","version":"1.0.0","type":"plugin","exists":false},
-	{"name":"wordpress","version":"3.0.0","type":"wordpress","exists":true}
-]
-```
+## More information
 
-**Example response 2** <https://patchstack.com/database/api/v2/batch>
-
-```json
-{
-    "vulnerabilities": {
-        "easy-digital-downloads1": [
-            {
-                "id": 4532,
-                "product_id": 1572,
-                "title": "WordPress Easy Digital Downloads plugin <= 2.10.2 - Cross-Site Request Forgery (CSRF) vulnerability",
-                "description": "Cross-Site Request Forgery (CSRF) vulnerability discovered by WPScan team in WordPress Easy Digital Downloads plugin (versions <= 2.10.2).",
-                "disclosure_date": "2021-04-16 00:00:00",
-                "disclosed_at": "2021-04-16T00:00:00+00:00",
-                "created_at": "2021-04-19T04:43:04+00:00",
-                "url": "wordpress-easy-digital-downloads-plugin-2-10-2-cross-site-request-forgery-csrf-vulnerability",
-                "product_slug": "easy-digital-downloads1",
-                "product_name": "Easy Digital Downloads",
-                "product_name_premium": null,
-                "product_type": "Plugin",
-                "vuln_type": "Cross Site Request Forgery (CSRF)",
-                "cvss_score": 6.5,
-                "cve": [],
-                "is_exploited": false,
-                "affected_in": "<= 2.10.2",
-                "fixed_in": "2.10.3",
-                "direct_url": "https://patchstack.com/database/vulnerability/easy-digital-downloads1/wordpress-easy-digital-downloads-plugin-2-10-2-cross-site-request-forgery-csrf-vulnerability"
-            },
-            {
-                "id": 5410,
-                "product_id": 1572,
-                "title": "WordPress Easy Digital Downloads plugin <= 2.11.2 - Authenticated Reflected Cross-Site Scripting (XSS) vulnerability",
-                "description": "Authenticated Reflected Cross-Site Scripting (XSS) vulnerability discovered by Thinkland Security Team in WordPress Easy Digital Downloads plugin (versions <= 2.11.2).",
-                "disclosure_date": "2021-10-21 00:00:00",
-                "disclosed_at": "2021-10-21T00:00:00+00:00",
-                "created_at": "2021-10-22T12:54:01+00:00",
-                "url": "wordpress-easy-digital-downloads-plugin-2-11-2-authenticated-reflected-cross-site-scripting-xss-vulnerability",
-                "product_slug": "easy-digital-downloads1",
-                "product_name": "Easy Digital Downloads",
-                "product_name_premium": null,
-                "product_type": "Plugin",
-                "vuln_type": "Cross Site Scripting (XSS)",
-                "cvss_score": 4.8,
-                "cve": [
-                    "2021-39354"
-                ],
-                "is_exploited": false,
-                "affected_in": "<= 2.11.2",
-                "fixed_in": "2.11.2.1",
-                "direct_url": "https://patchstack.com/database/vulnerability/easy-digital-downloads1/wordpress-easy-digital-downloads-plugin-2-11-2-authenticated-reflected-cross-site-scripting-xss-vulnerability"
-            }
-        ],
-        "wordpress": true
-    }
-}
-```
-
-### Find specific vulnerability by ID
-
-**Description:** Find a specific vulnerability by vulnerability id.  
-**Endpoint:** /vulnerability/ID  
-**Method:** GET
-
-**ID** = Numeric identifier or PSID of the vulnerability.
-
-**Example response 1** <https://patchstack.com/database/api/v2/vulnerability/4760>
-
-```json
-{
-    "vulnerability": {
-        "title": "WordPress Spam protection, AntiSpam, FireWall by CleanTalk plugin <= 5.153.3 - Unauthenticated Time-Based Blind SQL Injection (SQLi) vulnerability",
-        "description": "Unauthenticated Time-Based Blind SQL Injection (SQLi) vulnerability discovered by WordFence in WordPress Spam protection, AntiSpam, FireWall by CleanTalk plugin (versions <= 5.153.3).",
-        "disclosure_date": "2021-05-03 00:00:00",
-        "disclosed_at": "2021-05-03T00:00:00+00:00",
-        "created_at": "2021-09-28T14:17:02+00:00",
-        "is_exploited": true,
-        "url": "wordpress-spam-protection-antispam-firewall-by-cleantalk-plugin-5-153-3-unauthenticated-time-based-blind-sql-injection-sqli-vulnerability",
-        "direct_url": "https://patchstack.com/database/vulnerability/cleantalk-spam-protect/wordpress-spam-protection-antispam-firewall-by-cleantalk-plugin-5-153-3-unauthenticated-time-based-blind-sql-injection-sqli-vulnerability"
-    },
-    "product": {
-        "name": "Spam protection, AntiSpam, FireWall by CleanTalk",
-        "slug": "cleantalk-spam-protect",
-        "type": "Plugin"
-    },
-    "type": "SQL Injection",
-    "cvss": {
-        "score": 7.5,
-        "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-        "description": ""
-    },
-    "owasp": "A1: Injection",
-    "references_url": [
-        {
-            "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-24295",
-            "title": "CVE"
-        },
-        {
-            "url": "https://www.wordfence.com/blog/2021/05/sql-injection-vulnerability-patched-in-cleantalk-antispam-plugin/",
-            "title": "Vulnerability details"
-        },
-        {
-            "url": "https://wordpress.org/plugins/cleantalk-spam-protect/#developers",
-            "title": "Plugin changelog"
-        }
-    ],
-    "cve": [
-        "2021-24295"
-    ],
-    "versions": {
-        "affected_in": "<= 5.153.3",
-        "fixed_in": "5.153.4"
-    },
-    "versions_list": null,
-    "credit": {
-        "name": "WordFence",
-        "url": "https://twitter.com/wordfence"
-    },
-    "submitter": null
-}
-```
-
-**Example response 2** <https://patchstack.com/database/api/v2/vulnerability/4614>    
-
-```json
-{
-    "vulnerability": {
-        "title": "WordPress Simple File List plugin <= 4.2.2 - Unauthenticated Arbitrary File Upload vulnerability leading to Remote Code Execution (RCE)",
-        "description": "Unauthenticated Arbitrary File Upload vulnerability leading to Remote Code Execution (RCE) discovered by h00die and coiffeur in WordPress Simple File List plugin (versions <= 4.2.2).",
-        "disclosure_date": "2020-04-27 00:00:00",
-        "disclosed_at": "2020-04-27T00:00:00+00:00",
-        "created_at": "2021-04-23T15:55:02+00:00",
-        "is_exploited": false,
-        "url": "wordpress-simple-file-list-plugin-4-2-2-unauthenticated-arbitrary-file-upload-vulnerability-leading-to-remote-code-execution-rce",
-        "direct_url": "https://patchstack.com/database/vulnerability/simple-file-list/wordpress-simple-file-list-plugin-4-2-2-unauthenticated-arbitrary-file-upload-vulnerability-leading-to-remote-code-execution-rce"
-    },
-    "product": {
-        "name": "Simple File List",
-        "slug": "simple-file-list",
-        "type": "Plugin"
-    },
-    "type": "SQL Injection",
-    "cvss": {
-        "score": 9.8,
-        "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-        "description": ""
-    },
-    "owasp": "A1: Injection",
-    "references_url": [
-        {
-            "url": "https://packetstormsecurity.com/files/160221/",
-            "title": "Vulnerability details"
-        },
-        {
-            "url": "https://wordpress.org/plugins/simple-file-list/#developers",
-            "title": "Plugin changelog"
-        }
-    ],
-    "cve": [],
-    "versions": {
-        "affected_in": "<= 4.2.2",
-        "fixed_in": "4.2.3"
-    },
-    "versions_list": null,
-    "credit": {
-        "name": "coiffeur",
-        "url": "https://packetstormsecurity.com/files/author/14922/"
-    },
-    "submitter": {
-        "name": "h00die",
-        "url": "https://packetstormsecurity.com/files/author/7166/"
-    }
-}
-```
-
-**Example response 3** <https://patchstack.com/database/api/v2/vulnerability/4112>
-
-```json
-{
-    "vulnerability": {
-        "title": "WordPress Redux Framework <= 4.1.23 - Cross-Site Request Forgery (CSRF) Nonce Validation Bypass vulnerability",
-        "description": "Cross-Site Request Forgery (CSRF) Nonce Validation Bypass vulnerability found by ErwanLR in WordPress Redux Framework (versions 4.1.22 - 4.1.23).",
-        "disclosure_date": "2020-12-15 00:00:00",
-        "disclosed_at": "2020-12-15T00:00:00+00:00",
-        "created_at": "2020-12-15T18:36:01+00:00",
-        "is_exploited": false,
-        "url": "wordpress-redux-framework-4-1-23-cross-site-request-forgery-csrf-nonce-validation-bypass-vulnerability",
-        "direct_url": "https://patchstack.com/database/vulnerability/redux-framework/wordpress-redux-framework-4-1-23-cross-site-request-forgery-csrf-nonce-validation-bypass-vulnerability"
-    },
-    "product": {
-        "name": "Redux Framework",
-        "slug": "redux-framework",
-        "type": "Plugin"
-    },
-    "type": "SQL Injection",
-    "cvss": null,
-    "owasp": "A1: Injection",
-    "references_url": [
-        {
-            "url": "https://plugins.trac.wordpress.org/changeset/2437953/redux-framework/trunk/redux-core/inc/classes/class-redux-ajax-save.php?old=2405408",
-            "title": "Vulnerability details"
-        },
-        {
-            "url": "https://github.com/reduxframework/redux-framework-4/blob/master/CHANGELOG.md",
-            "title": "Plugin changelog"
-        }
-    ],
-    "cve": [],
-    "versions": {
-        "affected_in": "<= 4.1.23",
-        "fixed_in": "4.1.24"
-    },
-    "versions_list": "4.1.23, 4.1.22",
-    "credit": {
-        "name": "ErwanLR",
-        "url": "https://profiles.wordpress.org/erwanlr/"
-    },
-    "submitter": null
-}
-```
-
-## More information about the Threat Intelligence API
-
-You can find more information about Threat Intelligence API here:  
-<a href="https://patchstack.com/for-hosts" target="_blank">https://patchstack.com/for-hosts/</a>
+You can find more information about the Patchstack Threat Intelligence API on <https://patchstack.com/for-hosts/>. If you have integration questions, email <dave.jong@patchstack.com>.

--- a/src/content/docs/API solutions/Threat Intelligence API/extended.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/extended.md
@@ -15,6 +15,8 @@ sidebar:
 _The Extended Threat Intelligence API is a superset of the [Standard tier](/api-solutions/threat-intelligence-api/standard/). Extended has **custom pricing and is activated on request** — [contact us](https://patchstack.com/for-hosts/)._
 
 > **Interactive reference:** Every endpoint, parameter, request body and response shape is documented in the [Threat Intelligence API (Extended) reference](/api-reference/threat-intelligence-extended/).
+>
+> **Tooling (Postman, SDK, LLM):** spec URLs and import instructions for all three tiers live on [Overview → Using the APIs with your tools](/api-solutions/threat-intelligence-api/overview/#using-the-apis-with-your-tools).
 
 This page covers the concepts you need to use the API effectively — authentication, rate limiting, errors, and code samples. Use it alongside the interactive reference.
 
@@ -29,47 +31,6 @@ This page covers the concepts you need to use the API effectively — authentica
 | `POST /batch` — up to 50 products per request | — | ✓ |
 | `GET /vulnerability/{id}` — advisory detail (CVSS vector, OWASP, references, credit) | — | ✓ |
 | Rate limit | 5,000 / 24h | Custom, set per contract |
-
-## Use with Postman, Insomnia, Bruno or Hoppscotch
-
-We publish the API as an [OpenAPI 3.1 spec](https://docs.patchstack.com/schemas/threat-intel-extended.yaml) and a pre-built [Postman collection](https://docs.patchstack.com/schemas/threat-intel-extended.postman_collection.json). Every endpoint, parameter, request body and example is preconfigured — set your `PSKey` once and the whole collection authenticates.
-
-[Download the collection](/schemas/threat-intel-extended.postman_collection.json) and drag it into Postman/Insomnia/Bruno/Hoppscotch, or import it by URL from inside the tool.
-
-| Tool | How to import |
-|---|---|
-| **Postman** | `File → Import → Link` and paste the collection URL. |
-| **Insomnia** | `Create → Import From → URL` → paste the OpenAPI URL. |
-| **Bruno** | `Collection → Import → OpenAPI V3 Spec` → paste the OpenAPI URL. |
-| **Hoppscotch** | `Collections → Import/Export → OpenAPI` → paste the OpenAPI URL. |
-
-**Authentication:** in Postman set the collection `Authorization` to **API Key**, key `PSKey`, value `{{PSKEY}}`, and add `PSKEY` as a collection variable with your real key as the **Current value** (leave Initial blank so it doesn't sync to teammates). Other tools work the same way — set `PSKey` as a collection header once.
-
-## Use with Claude Code or other LLM coding assistants
-
-Point your assistant at the spec. LLMs parse OpenAPI cleanly and will generate clients that match the real field names instead of hallucinating.
-
-- **Ad hoc:** paste the spec URL into your prompt. Example: *"Write a Node script that walks `POST /batch` over a `package.json`-style list of plugins using `https://docs.patchstack.com/schemas/threat-intel-extended.yaml`."*
-- **In your repo:** download the spec to `docs/vendor/patchstack-threat-intel-extended.yaml` and reference it from your `CLAUDE.md` / `AGENTS.md`. Your assistant can then grep the YAML for specific fields without refetching.
-- **Plain-text fallback:** for tools that don't parse YAML, our [`llms-full.txt`](/llms-full.txt) contains the full reference as flat markdown.
-
-## SDK generation
-
-Generate a client in any language from the same spec:
-
-```bash
-# TypeScript
-npx @openapitools/openapi-generator-cli generate \
-  -i https://docs.patchstack.com/schemas/threat-intel-extended.yaml \
-  -g typescript-fetch -o ./patchstack-client
-
-# Python
-npx @openapitools/openapi-generator-cli generate \
-  -i https://docs.patchstack.com/schemas/threat-intel-extended.yaml \
-  -g python -o ./patchstack-client-py
-```
-
-Speakeasy and Fern also consume the same spec and produce more idiomatic SDKs if you need a polished client library.
 
 ## Base URL
 
@@ -112,9 +73,7 @@ Custom, set per contract. Contact <https://patchstack.com/for-hosts/> if you nee
 
 ---
 
-## Testing
-
-### curl — one-liners
+## Testing — curl one-liners
 
 ```bash
 # Latest 20 vulnerabilities
@@ -129,7 +88,7 @@ curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2' \
 curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2/exists' \
   -H 'PSKey: <your-api-key>'
 
-# Batch — boolean-only across three products
+# Batch — boolean-only across two products
 curl -X POST 'https://patchstack.com/database/api/v2/batch' \
   -H 'PSKey: <your-api-key>' \
   -H 'Content-Type: application/json' \
@@ -143,7 +102,7 @@ curl 'https://patchstack.com/database/api/v2/vulnerability/4760' \
   -H 'PSKey: <your-api-key>'
 ```
 
-### Batch walk (PHP)
+## Batch walk (PHP)
 
 ```php
 <?php
@@ -172,10 +131,6 @@ foreach ($response['vulnerabilities'] as $slug => $result) {
     }
 }
 ```
-
-### Postman / Insomnia / Bruno / Hoppscotch
-
-Import the OpenAPI spec directly from [`threat-intel-extended.yaml`](https://docs.patchstack.com/schemas/threat-intel-extended.yaml) — authentication, parameters and example payloads are preconfigured. Set the `PSKey` security value to your API key once and every request in the collection will use it.
 
 ## More information
 

--- a/src/content/docs/API solutions/Threat Intelligence API/overview.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/overview.md
@@ -12,7 +12,7 @@ sidebar:
   hidden: false
 ---
 
-Patchstack publishes three tiers of the Threat Intelligence API. Each tier has a narrative **Guide** and an interactive **Reference** generated from its OpenAPI spec — import the spec into Postman, Insomnia, Bruno, or a code-generation tool to get a working client in minutes.
+Patchstack publishes three tiers of the Threat Intelligence API. Each tier has a narrative **Guide** and an interactive **Reference** generated from its OpenAPI spec. All three specs use the same tooling for import, SDK generation, and LLM-assisted client writing — covered once in [Using the APIs with your tools](#using-the-apis-with-your-tools) below.
 
 ## Standard Threat Intelligence API
 
@@ -37,3 +37,56 @@ A new generation of the API, currently available to **selected partners working 
 **New integration?** If you have Beta access, use Beta — it's the direction we're heading, and Standard/Extended will eventually adopt the same nested shape. Otherwise start with Standard or Extended depending on your data needs.
 
 **Existing integration?** Standard and Extended remain supported; no migration is required. See [API properties](/api-solutions/threat-intelligence-api/api-properties/) for v2 field definitions.
+
+---
+
+## Using the APIs with your tools
+
+All three tiers ship the same three artefacts — pick whichever URL matches the tier you're integrating:
+
+| Tier | OpenAPI spec | Postman collection |
+|---|---|---|
+| Standard | [`threat-intel-standard.yaml`](/schemas/threat-intel-standard.yaml) | [`threat-intel-standard.postman_collection.json`](/schemas/threat-intel-standard.postman_collection.json) |
+| Extended | [`threat-intel-extended.yaml`](/schemas/threat-intel-extended.yaml) | [`threat-intel-extended.postman_collection.json`](/schemas/threat-intel-extended.postman_collection.json) |
+| Beta | [`threat-intel-beta.yaml`](/schemas/threat-intel-beta.yaml) | [`threat-intel-beta.postman_collection.json`](/schemas/threat-intel-beta.postman_collection.json) |
+
+### Postman, Insomnia, Bruno or Hoppscotch
+
+Every endpoint, parameter, request body and example is preconfigured. Download the Postman collection and drag it into your tool, or import by URL from inside the tool:
+
+| Tool | How to import |
+|---|---|
+| **Postman** | `File → Import → Link` and paste the collection URL. |
+| **Insomnia** | `Create → Import From → URL` → paste the OpenAPI URL. |
+| **Bruno** | `Collection → Import → OpenAPI V3 Spec` → paste the OpenAPI URL. |
+| **Hoppscotch** | `Collections → Import/Export → OpenAPI` → paste the OpenAPI URL. |
+
+**Authentication:** in Postman set the collection `Authorization` to **API Key**, key `PSKey`, value `{{PSKEY}}`, and add `PSKEY` as a collection variable with your real key as the **Current value** (leave Initial blank so it doesn't sync to teammates). Other tools work the same way — set `PSKey` as a collection header once.
+
+### Claude Code and other LLM coding assistants
+
+Point your assistant at the spec. LLMs parse OpenAPI cleanly and will generate clients that match the real field names instead of hallucinating.
+
+- **Ad hoc:** paste the spec URL into your prompt. Example: *"Write a Python client for `https://docs.patchstack.com/schemas/threat-intel-extended.yaml`. I need a batch walker over a `package.json`-style list."*
+- **In your repo:** download the spec to `docs/vendor/patchstack-threat-intel-<tier>.yaml` and reference it from your `CLAUDE.md` / `AGENTS.md`. Your assistant can then grep the YAML for specific fields without refetching.
+- **Plain-text fallback:** for tools that don't parse YAML, our [`llms-full.txt`](/llms-full.txt) contains the full reference as flat markdown.
+
+### SDK generation
+
+Generate a client in any language from the same spec — swap the spec URL for the tier you want:
+
+```bash
+# TypeScript (Extended tier shown)
+npx @openapitools/openapi-generator-cli generate \
+  -i https://docs.patchstack.com/schemas/threat-intel-extended.yaml \
+  -g typescript-fetch -o ./patchstack-client
+
+# Python
+npx @openapitools/openapi-generator-cli generate \
+  -i https://docs.patchstack.com/schemas/threat-intel-extended.yaml \
+  -g python -o ./patchstack-client-py
+```
+
+Speakeasy and Fern also consume the same spec and produce more idiomatic SDKs if you need a polished client library.
+
+> **Spec stability:** the Beta spec may change without a version bump while the API is in beta. Pin a commit of the YAML in production integrations, or wait for the GA release when we'll publish versioned URLs. Standard and Extended specs track the stable v2 surface.

--- a/src/content/docs/API solutions/Threat Intelligence API/overview.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/overview.md
@@ -12,39 +12,28 @@ sidebar:
   hidden: false
 ---
 
-Patchstack publishes three ways to consume its vulnerability database. Standard and Extended are the stable tiers of the v2 API; the Npm Dataset API (Beta) is a new generation available to selected partners only.
+Patchstack publishes three tiers of the Threat Intelligence API. Each tier has a narrative **Guide** and an interactive **Reference** generated from its OpenAPI spec — import the spec into Postman, Insomnia, Bruno, or a code-generation tool to get a working client in minutes.
 
-## Which API should I use?
+## Standard Threat Intelligence API
 
-| | **Standard** | **Extended** | **Beta** |
-|---|---|---|---|
-| **Status** | Stable (v2) | Stable (v2) | Beta — selected partners only |
-| **Access** | Purchase via [Patchstack App](https://app.patchstack.com/billing/subscription) | Custom pricing, activated on request — [contact us](https://patchstack.com/for-hosts/) | By invitation. If you're working with Patchstack on an integration, [get in touch](https://patchstack.com/for-hosts/) |
-| **Rate limit** | 5,000 calls / 24 hours | Custom | Custom |
-| **Ecosystems** | WordPress plugins, themes, core | WordPress plugins, themes, core | WordPress + **npm** |
-| **Lookups** | Single plugin/theme/version | Single + bulk | Single + bulk |
-| **Pagination** | Offset | Offset | Offset **and** cursor |
-| **Response shape** | Flat | Flat | Nested (`product`, `cvss`, `cwe`, `version_info`…) |
-| **Full advisory body** | No | Yes | Opt-in via `?include=details` |
-| **OpenAPI spec / Postman collection** | — | — | [Yes](/api-solutions/threat-intelligence-api/beta/#use-with-postman-insomnia-bruno-or-hoppscotch) |
+WordPress plugin, theme and core lookups for a single product + version. Flat per-item shape, 5,000 requests / 24 hours. Purchase access from the [Patchstack App](https://app.patchstack.com/billing/subscription).
 
-**New integration?** If you have Beta access, use Beta — it's the direction we're heading, and Standard/Extended will eventually adopt the same shape. If not, start with Standard or Extended depending on your data needs.
+- [Guide](/api-solutions/threat-intelligence-api/standard/) · [Reference](/api-reference/threat-intelligence-standard/) · [OpenAPI](/schemas/threat-intel-standard.yaml) · [Postman](/schemas/threat-intel-standard.postman_collection.json)
 
-**Existing integration?** Standard and Extended remain supported; no migration is required.
+## Extended Threat Intelligence API
+
+Everything in Standard, plus bulk lookups (`POST /batch`, up to 50 products per request), the `/latest` rolling feed, advisory-by-id detail, and a richer per-item payload (`cvss_score`, `cve`, `is_exploited`, `patch_priority`, `patched_in_ranges`…). Custom pricing, activated on request — [contact us](https://patchstack.com/for-hosts/).
+
+- [Guide](/api-solutions/threat-intelligence-api/extended/) · [Reference](/api-reference/threat-intelligence-extended/) · [OpenAPI](/schemas/threat-intel-extended.yaml) · [Postman](/schemas/threat-intel-extended.postman_collection.json)
+
+## Npm Dataset API (Beta)
+
+A new generation of the API, currently available to **selected partners working directly with Patchstack**. Adds npm ecosystem coverage, an opt-in full advisory body (`?include=details`), a consistent nested response shape (`product`, `cvss`, `cwe`, `version_info`…), and cursor-based pagination alongside offset. If you're already working with us on an integration and would like access, [contact us](https://patchstack.com/for-hosts/).
+
+- [Guide](/api-solutions/threat-intelligence-api/beta/) · [Reference](/api-reference/threat-intelligence-beta/) · [OpenAPI](/schemas/threat-intel-beta.yaml) · [Postman](/schemas/threat-intel-beta.postman_collection.json)
 
 ---
 
-### Standard Threat Intelligence API
-Fetch the latest vulnerability information for a single version of a particular plugin, theme or WordPress core. API is limited for 5000 calls / 24 hours. Access to this API can be purchased through the [Patchstack App](https://app.patchstack.com/billing/subscription).
+**New integration?** If you have Beta access, use Beta — it's the direction we're heading, and Standard/Extended will eventually adopt the same nested shape. Otherwise start with Standard or Extended depending on your data needs.
 
-[Standard Threat Intelligence API Documentation](/api-solutions/threat-intelligence-api/standard/)
-
-### Extended Threat Intelligence API
-Access everything included in the Standard tier, bulk-request data for multiple plugins with one API call, and have additional endpoints with more information about vulnerabilities. Extended tier has custom pricing and is activated on request only. For access to these API endpoints, please [contact us here](https://patchstack.com/for-hosts/).
-
-[Extended Threat Intelligence API Documentation](/api-solutions/threat-intelligence-api/extended/)
-
-### Beta Threat Intelligence API
-A new generation of the Threat Intelligence API, currently available to **selected partners working directly with Patchstack**. Adds npm ecosystem coverage, an opt-in full advisory body (`?include=details`), a consistent nested response shape, and cursor-based pagination alongside the existing offset pagination. If you're already working with us on an integration and would like access, [contact us](https://patchstack.com/for-hosts/).
-
-[Beta Threat Intelligence API Documentation](/api-solutions/threat-intelligence-api/beta/)
+**Existing integration?** Standard and Extended remain supported; no migration is required. See [API properties](/api-solutions/threat-intelligence-api/api-properties/) for v2 field definitions.

--- a/src/content/docs/API solutions/Threat Intelligence API/standard.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/standard.md
@@ -14,49 +14,10 @@ sidebar:
 _The Standard Threat Intelligence API is the entry-level tier of the v2 API. It returns every advisory that applies to a single WordPress plugin, theme or core version. If you need bulk lookups, the latest-24h feed, or advisory-by-id details, see the [Extended tier](/api-solutions/threat-intelligence-api/extended/)._
 
 > **Interactive reference:** Every endpoint, parameter and response shape is documented in the [Threat Intelligence API (Standard) reference](/api-reference/threat-intelligence-standard/).
+>
+> **Tooling (Postman, SDK, LLM):** spec URLs and import instructions for all three tiers live on [Overview → Using the APIs with your tools](/api-solutions/threat-intelligence-api/overview/#using-the-apis-with-your-tools).
 
 This page covers the concepts you need to use the API effectively — authentication, rate limiting, errors, and code samples. Use it alongside the interactive reference.
-
-## Use with Postman, Insomnia, Bruno or Hoppscotch
-
-We publish the API as an [OpenAPI 3.1 spec](https://docs.patchstack.com/schemas/threat-intel-standard.yaml) and a pre-built [Postman collection](https://docs.patchstack.com/schemas/threat-intel-standard.postman_collection.json). Every endpoint, parameter and example is preconfigured — set your `PSKey` once and the whole collection authenticates.
-
-[Download the collection](/schemas/threat-intel-standard.postman_collection.json) and drag it into Postman/Insomnia/Bruno/Hoppscotch, or import it by URL from inside the tool.
-
-| Tool | How to import |
-|---|---|
-| **Postman** | `File → Import → Link` and paste the collection URL. |
-| **Insomnia** | `Create → Import From → URL` → paste the OpenAPI URL. |
-| **Bruno** | `Collection → Import → OpenAPI V3 Spec` → paste the OpenAPI URL. |
-| **Hoppscotch** | `Collections → Import/Export → OpenAPI` → paste the OpenAPI URL. |
-
-**Authentication:** in Postman set the collection `Authorization` to **API Key**, key `PSKey`, value `{{PSKEY}}`, and add `PSKEY` as a collection variable with your real key as the **Current value** (leave Initial blank so it doesn't sync to teammates). Other tools work the same way — set `PSKey` as a collection header once.
-
-## Use with Claude Code or other LLM coding assistants
-
-Point your assistant at the spec. LLMs parse OpenAPI cleanly and will generate clients that match the real field names instead of hallucinating.
-
-- **Ad hoc:** paste the spec URL into your prompt. Example: *"Write a PHP client for `https://docs.patchstack.com/schemas/threat-intel-standard.yaml`. I need a function that takes a slug + version and returns the advisory list."*
-- **In your repo:** download the spec to `docs/vendor/patchstack-threat-intel-standard.yaml` and reference it from your `CLAUDE.md` / `AGENTS.md`. Your assistant can then grep the YAML for specific fields without refetching.
-- **Plain-text fallback:** for tools that don't parse YAML, our [`llms-full.txt`](/llms-full.txt) contains the full reference as flat markdown.
-
-## SDK generation
-
-Generate a client in any language from the same spec:
-
-```bash
-# TypeScript
-npx @openapitools/openapi-generator-cli generate \
-  -i https://docs.patchstack.com/schemas/threat-intel-standard.yaml \
-  -g typescript-fetch -o ./patchstack-client
-
-# Python
-npx @openapitools/openapi-generator-cli generate \
-  -i https://docs.patchstack.com/schemas/threat-intel-standard.yaml \
-  -g python -o ./patchstack-client-py
-```
-
-Speakeasy and Fern also consume the same spec and produce more idiomatic SDKs if you need a polished client library.
 
 ## Base URL
 
@@ -94,9 +55,7 @@ Standard is limited to **5,000 requests per 24 hours**. Contact <https://patchst
 
 ---
 
-## Testing
-
-### curl — one-liners
+## Testing — curl one-liners
 
 ```bash
 # Full advisory list for a plugin version
@@ -111,10 +70,6 @@ curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2/exists' 
 curl 'https://patchstack.com/database/api/v2/product/wordpress/wordpress/5.8.2' \
   -H 'PSKey: <your-api-key>'
 ```
-
-### Postman / Insomnia / Bruno / Hoppscotch
-
-Import the OpenAPI spec directly from [`threat-intel-standard.yaml`](https://docs.patchstack.com/schemas/threat-intel-standard.yaml) — authentication and parameters are preconfigured. Set the `PSKey` security value to your API key once and every request in the collection will use it.
 
 ## More information
 

--- a/src/content/docs/API solutions/Threat Intelligence API/standard.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/standard.md
@@ -1,77 +1,121 @@
 ---
 title: "Standard tier API"
-excerpt: ""
-metadata: 
+excerpt: "Entry-level WordPress vulnerability lookup — single product + version, 5,000 requests per day."
+metadata:
   image: []
   robots: "index"
 createdAt: "Mon Jul 25 2022 09:28:24 GMT+0000 (Coordinated Universal Time)"
 updatedAt: "Wed May 10 2023 12:26:10 GMT+0000 (Coordinated Universal Time)"
 sidebar:
   order: 1
+  label: "Guide"
 ---
 
-_If you’re looking for an API that has a complete data coverage and could be used commercially, please look at the Extended Threat Intelligence API <a href="https://patchstack.com/for-hosts" target="_blank">here</a>._
+_The Standard Threat Intelligence API is the entry-level tier of the v2 API. It returns every advisory that applies to a single WordPress plugin, theme or core version. If you need bulk lookups, the latest-24h feed, or advisory-by-id details, see the [Extended tier](/api-solutions/threat-intelligence-api/extended/)._
 
-## API Usage
+> **Interactive reference:** Every endpoint, parameter and response shape is documented in the [Threat Intelligence API (Standard) reference](/api-reference/threat-intelligence-standard/).
 
-The Standard Threat Intelligence API is limited to 5000 requests per 24 hours.
+This page covers the concepts you need to use the API effectively — authentication, rate limiting, errors, and code samples. Use it alongside the interactive reference.
 
-The base URL of the API is <https://patchstack.com/database/api/v2/>
+## Use with Postman, Insomnia, Bruno or Hoppscotch
 
-All responses are in JSON format. For performance reasons, responses are cached until we update the database after which the appropriate caches are cleared.
+We publish the API as an [OpenAPI 3.1 spec](https://docs.patchstack.com/schemas/threat-intel-standard.yaml) and a pre-built [Postman collection](https://docs.patchstack.com/schemas/threat-intel-standard.postman_collection.json). Every endpoint, parameter and example is preconfigured — set your `PSKey` once and the whole collection authenticates.
 
-An API key is required. This API key should be present in the _PSKey_ HTTP request header. You can request an API key by logging into your Patchstack App account and then by going to the Upgrades page <https://app.patchstack.com/billing/subscription>.
+[Download the collection](/schemas/threat-intel-standard.postman_collection.json) and drag it into Postman/Insomnia/Bruno/Hoppscotch, or import it by URL from inside the tool.
 
-Explanation of the API response properties can be found here [here](/api-solutions/threat-intelligence-api/api-properties/).
+| Tool | How to import |
+|---|---|
+| **Postman** | `File → Import → Link` and paste the collection URL. |
+| **Insomnia** | `Create → Import From → URL` → paste the OpenAPI URL. |
+| **Bruno** | `Collection → Import → OpenAPI V3 Spec` → paste the OpenAPI URL. |
+| **Hoppscotch** | `Collections → Import/Export → OpenAPI` → paste the OpenAPI URL. |
 
-## Find Vulnerability
+**Authentication:** in Postman set the collection `Authorization` to **API Key**, key `PSKey`, value `{{PSKEY}}`, and add `PSKEY` as a collection variable with your real key as the **Current value** (leave Initial blank so it doesn't sync to teammates). Other tools work the same way — set `PSKey` as a collection header once.
 
-**Description:** Retrieve vulnerabilities of a specific plugin, theme or WordPress core version.  
-**Endpoint:** /product/TYPE/NAME/VERSION/EXISTS?  
-**Method:** GET
+## Use with Claude Code or other LLM coding assistants
 
-**TYPE** = theme, plugin, wordpress  
-**NAME** = Slug of the theme, slug of the plugin, or “wordpress” in case TYPE is set to wordpress  
-**VERSION** = Version to check for vulnerabilities  
-**EXISTS** = Optional flag that will not return all vulnerabilities but only a boolean response whether or not there are vulnerabilities. This flag being present results in a faster response.
+Point your assistant at the spec. LLMs parse OpenAPI cleanly and will generate clients that match the real field names instead of hallucinating.
 
-Example response (<https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2>):
+- **Ad hoc:** paste the spec URL into your prompt. Example: *"Write a PHP client for `https://docs.patchstack.com/schemas/threat-intel-standard.yaml`. I need a function that takes a slug + version and returns the advisory list."*
+- **In your repo:** download the spec to `docs/vendor/patchstack-threat-intel-standard.yaml` and reference it from your `CLAUDE.md` / `AGENTS.md`. Your assistant can then grep the YAML for specific fields without refetching.
+- **Plain-text fallback:** for tools that don't parse YAML, our [`llms-full.txt`](/llms-full.txt) contains the full reference as flat markdown.
 
-```json
-{
-    "vulnerabilities": [
-				{
-            "id": 4253,
-            "title": "WordPress Tutor LMS plugin <= 1.5.2 - Cross-Site Request Forgery (CSRF) vulnerability",
-            "disclosed_at": "2020-02-04T00:00:00+00:00",
-            "created_at": "2022-05-27T10:23:01+00:00",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "fixed_in": "1.5.3",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-5-2-cross-site-request-forgery-csrf-vulnerability"
-        },
-        {
-            "id": 4386,
-            "title": "WordPress Tutor LMS plugin <= 1.7.6 - Multiple Blind/Time-based SQL Injection (SQLi) vulnerabilities",
-            "disclosed_at": "2021-03-15T00:00:00+00:00",
-            "created_at": "2022-05-27T10:23:01+00:00",
-            "product_slug": "tutor",
-            "product_name": "Tutor LMS",
-            "product_name_premium": null,
-            "product_type": "Plugin",
-            "fixed_in": "1.7.7",
-            "direct_url": "https://patchstack.com/database/vulnerability/tutor/wordpress-tutor-lms-plugin-1-7-6-multiple-blind-time-based-sql-injection-sqli-vulnerabilities"
-        }
-    ]
-}
+## SDK generation
+
+Generate a client in any language from the same spec:
+
+```bash
+# TypeScript
+npx @openapitools/openapi-generator-cli generate \
+  -i https://docs.patchstack.com/schemas/threat-intel-standard.yaml \
+  -g typescript-fetch -o ./patchstack-client
+
+# Python
+npx @openapitools/openapi-generator-cli generate \
+  -i https://docs.patchstack.com/schemas/threat-intel-standard.yaml \
+  -g python -o ./patchstack-client-py
 ```
 
-Example response (<https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2/exists>):
+Speakeasy and Fern also consume the same spec and produce more idiomatic SDKs if you need a polished client library.
 
-```json
-{
-	"vulnerable": true
-}
+## Base URL
+
 ```
+https://patchstack.com/database/api/v2/
+```
+
+## Authentication
+
+Every request must include your API key in the **`PSKey`** HTTP request header. You can request an API key from your [Patchstack App billing page](https://app.patchstack.com/billing/subscription).
+
+```
+PSKey: <your-api-key>
+```
+
+## Response format
+
+All responses are JSON. Responses are cached until the Patchstack database updates, at which point the cache is cleared.
+
+The Standard tier returns a **flat** per-item shape. For the richer shape with `description`, `vuln_type`, `cvss_score`, `cve`, and `patched_in_ranges`, use the [Extended tier](/api-solutions/threat-intelligence-api/extended/). Field definitions live in [API properties](/api-solutions/threat-intelligence-api/api-properties/).
+
+## Rate limiting
+
+Standard is limited to **5,000 requests per 24 hours**. Contact <https://patchstack.com/for-hosts/> if you need a higher quota or the Extended tier.
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `401 Unauthorized` | Missing or invalid `PSKey` header. |
+| `403 Forbidden` | API key not authorised for the requested endpoint. |
+| `404 Not Found` | Unknown product/version combination. |
+| `429 Too Many Requests` | Rate limit exceeded. |
+| `500` | Server error — please include the request id in any bug report. |
+
+---
+
+## Testing
+
+### curl — one-liners
+
+```bash
+# Full advisory list for a plugin version
+curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2' \
+  -H 'PSKey: <your-api-key>'
+
+# Boolean-only exists check (faster)
+curl 'https://patchstack.com/database/api/v2/product/plugin/tutor/1.5.2/exists' \
+  -H 'PSKey: <your-api-key>'
+
+# WordPress core
+curl 'https://patchstack.com/database/api/v2/product/wordpress/wordpress/5.8.2' \
+  -H 'PSKey: <your-api-key>'
+```
+
+### Postman / Insomnia / Bruno / Hoppscotch
+
+Import the OpenAPI spec directly from [`threat-intel-standard.yaml`](https://docs.patchstack.com/schemas/threat-intel-standard.yaml) — authentication and parameters are preconfigured. Set the `PSKey` security value to your API key once and every request in the collection will use it.
+
+## More information
+
+You can find more information about the Patchstack Threat Intelligence API on <https://patchstack.com/for-hosts/>. If you have integration questions, email <dave.jong@patchstack.com>.

--- a/src/content/docs/FAQ Troubleshooting/Technical/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-27001-or-other-security-checks.md
+++ b/src/content/docs/FAQ Troubleshooting/Technical/will-patchstack-plugin-help-my-site-pass-pci-dss-soc2-iso-27001-or-other-security-checks.md
@@ -1,5 +1,5 @@
 ---
-title: "Will Patchstack plugin help my site pass PCI-DSS, SOC2, ISO 127001 or other security checks?"
+title: "Will Patchstack plugin help my site pass PCI-DSS, SOC2, ISO 27001 or other security checks?"
 excerpt: ""
 hidden: false
 metadata: 

--- a/src/content/docs/Getting Started/start-using-patchstack.md
+++ b/src/content/docs/Getting Started/start-using-patchstack.md
@@ -41,7 +41,7 @@ To add the first site:
 
 ### Step #3 — Review vulnerabilities
 
-Patchstack shows your site for existing plugin & theme vulnerabilities. After that, check your dashboard to see a detailed breakdown of vulnerabilities by patch prioriy and severiy score.
+Patchstack shows your site for existing plugin & theme vulnerabilities. After that, check your dashboard to see a detailed breakdown of vulnerabilities by patch priority and severity score.
 
 Take immediate action on the **High Priority** vulnerabilities.
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -136,11 +136,3 @@ header button {
 .main-frame {
 	margin-bottom: 30px;
 }
-
-/* Match sidebar group labels that carry a badge (e.g. Npm Dataset API (Beta) [New]) to the
-   weight/size of sibling leaf links, so the badge carries the emphasis
-   instead of the label doubling up. */
-.group-label .large:has(+ .sl-badge) {
-	font-size: var(--sl-text-sm);
-	font-weight: normal;
-}


### PR DESCRIPTION
## Summary
- Brings the Standard and Extended tiers up to the same doc pattern as the Beta (Npm Dataset) tier landed in #22: hand-authored OpenAPI 3.1 specs drive an interactive reference, and deterministic Postman collections are generated at build time.
- Guide pages slimmed to narrative content (auth, rate limits, errors, curl samples, tier-specific concepts); shared Postman / LLM / SDK tooling content is consolidated into a single section on the Overview so all three Guides link to one source of truth.
- Sidebar nests each tier as **Guide + Reference** via per-schema `createOpenAPISidebarGroup()` placeholders. Removes a CSS rule that deliberately de-emphasised badged sidebar group labels — it made Beta look lighter than its Standard/Extended peers after this restructure.

### New files
- `public/schemas/threat-intel-standard.yaml` — OpenAPI 3.1, 2 operations (`/product/{type}/{name}/{version}`, `/.../exists`)
- `public/schemas/threat-intel-extended.yaml` — OpenAPI 3.1, 5 operations (`/latest`, `/product/...`, `/.../exists`, `/batch`, `/vulnerability/{id}`)
- Generated Postman collections for both

### Changed
- `astro.config.mjs` — three OpenAPI schemas registered, sidebar reworked
- `overview.md` — comparison table removed; three tier pointer blocks + consolidated tooling section
- `standard.md`, `extended.md` — slimmed to tier-specific content
- `beta.md` — shared tooling section removed, links to Overview
- `src/styles/custom.css` — dropped the sidebar badge de-emphasis rule

### Needs QA / API-team review
- **Spec accuracy.** The Standard and Extended YAMLs were hand-authored from the existing markdown. Fields, error codes, and response shapes should be sanity-checked against the live v2 API before partners start importing the spec as truth.
- **Visual walk of the sidebar + reference pages.** Especially the new Reference operation pages under `/api-reference/threat-intelligence-standard/` and `/api-reference/threat-intelligence-extended/`.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Sidebar renders **Overview → Standard API (Guide + Reference) → Extended API (Guide + Reference) → NPM standard API [Beta] (Guide + Reference) → API properties**
- [ ] All three tier group labels render at the same visual weight
- [ ] Each Reference operation page renders parameters, request bodies, response schemas, and examples
- [ ] Postman collection import works (drag `threat-intel-standard.postman_collection.json` and `threat-intel-extended.postman_collection.json` into Postman, set PSKey, run a request)
- [ ] Generated Postman JSONs are byte-identical across consecutive builds (verified locally, worth one more confirmation post-merge)
- [ ] Inbound deep links to `#find-vulnerability` etc. will now land on the page but not a section anchor — confirm acceptable
- [ ] API team signs off on spec accuracy for Standard and Extended

🤖 Generated with [Claude Code](https://claude.com/claude-code)