### PR TITLE
Add Dependabot config for weekly npm and Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      non-major:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` modeled on the hub repo's setup
- Weekly **npm** checks at `/` and weekly **github-actions** checks at `/`
- Groups minor/patch bumps into a single PR (`non-major` group); labels `dependencies` + `frontend`/`ci`
- Ignores routine major version bumps; Dependabot security updates still bypass this rule, so vulnerability-driven majors will come through

## Test plan
- [ ] Once merged to `main`, confirm Dependabot runs on schedule (Insights → Dependency graph → Dependabot)
- [ ] Verify first PR batch is grouped as `non-major` and labeled correctly
- [ ] Confirm no standalone major-version PRs appear for routine releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)