### PR TITLE
Fix Threat Intelligence Beta base URL to vdp-api host

### DIFF
--- a/public/schemas/threat-intel-beta.postman_collection.json
+++ b/public/schemas/threat-intel-beta.postman_collection.json
@@ -1750,7 +1750,7 @@
   "variable": [
     {
       "type": "string",
-      "value": "https://patchstack.com/database/api/beta",
+      "value": "https://vdp-api.patchstack.com/database/api/beta",
       "key": "baseUrl"
     }
   ],

--- a/public/schemas/threat-intel-beta.yaml
+++ b/public/schemas/threat-intel-beta.yaml
@@ -75,7 +75,7 @@ info:
     email: dave.jong@patchstack.com
 
 servers:
-  - url: https://patchstack.com/database/api/beta
+  - url: https://vdp-api.patchstack.com/database/api/beta
     description: Beta
 
 security:

--- a/src/content/docs/API solutions/Threat Intelligence API/beta.md
+++ b/src/content/docs/API solutions/Threat Intelligence API/beta.md
@@ -17,7 +17,7 @@ _The Beta surface extends the Threat Intelligence API ahead of GA. It runs at a 
 ## Base URL
 
 ```
-https://patchstack.com/database/api/beta/
+https://vdp-api.patchstack.com/database/api/beta/
 ```
 
 ## What's new
@@ -80,19 +80,19 @@ In addition to the [stable error codes](/api-solutions/threat-intelligence-api/e
 
 ```bash
 # Latest 24h, npm
-curl 'https://patchstack.com/database/api/beta/latest?platform=npm&per_page=10' \
+curl 'https://vdp-api.patchstack.com/database/api/beta/latest?platform=npm&per_page=10' \
   -H 'PSKey: <your-api-key>'
 
 # Cursor pagination walk (bootstrap + follow)
-curl 'https://patchstack.com/database/api/beta/all?platform=npm&per_page=50&cursor=' \
+curl 'https://vdp-api.patchstack.com/database/api/beta/all?platform=npm&per_page=50&cursor=' \
   -H 'PSKey: <your-api-key>'
 
 # Check a specific npm package/version with full advisory text
-curl 'https://patchstack.com/database/api/beta/product/npm/axios/0.21.4?include=details' \
+curl 'https://vdp-api.patchstack.com/database/api/beta/product/npm/axios/0.21.4?include=details' \
   -H 'PSKey: <your-api-key>'
 
 # Boolean-only exists check
-curl 'https://patchstack.com/database/api/beta/product/npm/axios/0.21.4/exists' \
+curl 'https://vdp-api.patchstack.com/database/api/beta/product/npm/axios/0.21.4/exists' \
   -H 'PSKey: <your-api-key>'
 ```
 
@@ -100,7 +100,7 @@ curl 'https://patchstack.com/database/api/beta/product/npm/axios/0.21.4/exists' 
 
 ```javascript
 async function* allVulnerabilities(apiKey, platform = 'npm', perPage = 100) {
-  const base = 'https://patchstack.com/database/api/beta/all';
+  const base = 'https://vdp-api.patchstack.com/database/api/beta/all';
   let cursor = '';            // empty = bootstrap cursor mode
 
   while (true) {
@@ -131,7 +131,7 @@ $apiKey = getenv('PATCHSTACK_KEY');
 $cursor = '';
 
 do {
-    $url = 'https://patchstack.com/database/api/beta/all'
+    $url = 'https://vdp-api.patchstack.com/database/api/beta/all'
         .'?platform=npm&per_page=100&cursor='.urlencode($cursor);
 
     $ch = curl_init($url);


### PR DESCRIPTION
## Summary
- Update Beta API base URL from `https://patchstack.com/database/api/beta/` to `https://vdp-api.patchstack.com/database/api/beta/` in the NPM Beta docs page, OpenAPI spec (`servers`), and Postman collection (`baseUrl`).
- Ensures the interactive API reference and all curl/JS/PHP examples target the correct host.

## Test plan
- [ ] Verify the rendered Beta page shows the new base URL
- [ ] Verify the interactive API reference for Threat Intelligence Beta uses `vdp-api.patchstack.com`
- [ ] Verify the Postman collection `baseUrl` variable resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)