### PR TITLE
[NO-TICKET] Clarify that siteid and oauth.id are independent fields

### DIFF
--- a/src/content/docs/API solutions/App API/patchstack-integration.md
+++ b/src/content/docs/API solutions/App API/patchstack-integration.md
@@ -119,18 +119,38 @@ The response will look something like below.
 {
   "success": "Successfully added the site(s).",
   "count": 1,
+  "sites": {
+    "https://mywebsite.com": {
+      "siteid": 12345,
+      "oauth": {
+        "id": 12333,
+        "secret": "DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR",
+        "apikey": "DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR-12333"
+      }
+    }
+  },
   "lastid": 12345,
   "oauth": {
-    "id": 12345,
-    "secret": "DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR"
+    "id": 12333,
+    "secret": "DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR",
+    "apikey": "DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR-12333"
   }
 }
 ```
 
-###### 3. Store in local datastore
-It is now important to store the lastid and oauth properties into a datastore on your infrastructure. This allows you to know the site identifier of the website of the customer without having to query the Patchstack App API each time. This can then be used for most of our other API endpoints to fetch information for the site.
+The top-level `lastid` and `oauth` fields refer to the **last** site in the batch and are kept for backwards compatibility. New integrations should read from the per-URL `sites` map.
 
-The API key that is used in the plugin, contains the format `oauth.secret-oauth.id`, for example in above response it would be `DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR-12345`.
+###### 3. Store in local datastore
+Store the `siteid` and `apikey` for each URL in a datastore on your infrastructure. This avoids having to query the Patchstack App API each time you need to identify a customer's site.
+
+- **`siteid`** is the canonical Patchstack site identifier. It is what the portal displays and what every per-site API endpoint expects in the URL (`/site/view/{siteid}`, `/site/{siteid}/delete`, `/download/wordpress/{siteid}`, etc.). Store this if you ever need to cross-reference your records against the Patchstack portal.
+- **`apikey`** is the pre-formatted plugin license key (`<oauth.secret>-<oauth.id>`). Pass it directly to the WordPress plugin during activation — you do not need to assemble it yourself.
+
+:::note[`siteid` and `oauth.id` are independent fields]
+`siteid` identifies the site, `oauth.id` identifies the OAuth credential embedded in the plugin license key. They have always been independent fields with different purposes. Do not assume they are equal — for sites provisioned before 13 May 2026 the two values often coincided as a side-effect of how rows were inserted, but they may differ for any site provisioned since.
+
+If you previously stored `oauth.id` under the assumption it equalled the site identifier, call [`POST /monitor/sites/list/basic`](https://api.patchstack.com/app-api/documentation) to fetch `[{id, url}, …]` for every site on your account, match by URL, and update your stored values to the current `siteid`.
+:::
 
 ### Step 3: Plugin deployment
 Now that you have the site identifier and plugin API key stored in your local datastore, you can start the flow of installing and activating the Patchstack plugin on the website.
@@ -153,9 +173,9 @@ First we execute the command below to install and activate the Patchstack plugin
 
 `wp plugin install patchstack --activate`
 
-Then we execute the command below to activate the connection to Patchstack. It is important to inject the plugin API key here we retrieved from step 2:
+Then we execute the command below to activate the connection to Patchstack. It is important to inject the plugin API key (`apikey` from step 2) here:
 
-`wp patchstack activate DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR-12345`
+`wp patchstack activate DOOs9DIyv2FMcURFtkB0eXOHMRhH7I2EsaNUb4aR-12333`
 
 This command will return `The Patchstack plugin has been successfully connected.` if it succeeded.
 
@@ -285,4 +305,21 @@ Which outputs the following:
 {
   "activated": true
 }
+```
+
+### What's the difference between `siteid` and `oauth.id`? Can I assume they're equal?
+They are two independent fields with different purposes — do not assume they are equal.
+
+- **`siteid`** is the canonical Patchstack site identifier. It is what the portal displays and what every per-site API endpoint expects (e.g. `/site/view/{siteid}`, `/site/{siteid}/delete`, `/download/wordpress/{siteid}`). Store this for cross-referencing your records against the Patchstack portal.
+- **`oauth.id`** is the OAuth credential identifier. Its only purpose is to form the plugin license key, which the `/site/add` response already returns pre-formatted as `apikey` (`<oauth.secret>-<oauth.id>`). You never need to read `oauth.id` as a standalone value — just pass `apikey` to the plugin.
+
+For sites provisioned before 13 May 2026, `siteid` and `oauth.id` coincidentally held the same value because of how rows were inserted in our database. They may differ for any site provisioned since. If you previously stored `oauth.id` under the assumption it equalled the site identifier, see the [callout in step 2 of integration](#3-store-in-local-datastore) for how to reconcile your stored values.
+
+### How can I reconcile site IDs in my datastore against the Patchstack portal?
+Call [`POST /monitor/sites/list/basic`](https://api.patchstack.com/app-api/documentation) with the same `UserToken` you use for `/site/add`. It returns `[{id, url}, …]` for every site on your account, where `id` is the current `siteid`. Match by URL and update your stored values.
+
+```bash
+curl -X 'POST' \
+  'https://api.patchstack.com/monitor/sites/list/basic' \
+  -H 'UserToken: <token>' \
 ```


### PR DESCRIPTION
## Summary

The partner integration guide previously showed `lastid` and `oauth.id` holding the same value (`12345`) in the `/site/add` response example, implying the two are equivalent. They never were — they're two independent identifiers serving different purposes, but they happened to coincide because of how rows were inserted in our database.

That implicit invariant broke on **13 May 2026** when our Pulse / NPM-application monitoring feature shipped: its provisioning path inserts a site row without a matching OAuth row, so the two auto-increment sequences no longer move in lock-step. Partners who stored `oauth.id` assuming it equalled `siteid` started seeing the two diverge in their datastores vs. the portal (e.g. one hosting partner had ~70 affected sites and filed a support ticket).

The runtime fix landed in saas#561 (and we've decided not to back-fill — see saas#562). This PR closes the loop on the documentation side so the same confusion can't happen again.

## What changes in `patchstack-integration.md`

- **Response example** (`/site/add`) now uses distinct values (`siteid: 12345`, `oauth.id: 12333`) and shows the modern per-URL `sites` map alongside the legacy top-level `lastid` / `oauth` fields. Notes that the top-level fields are kept for backwards compat but new integrations should read `sites`.
- **"Store in local datastore"** explicitly distinguishes what each field is for:
  - `siteid` — canonical site identifier, used in portal + every per-site API path. Store this for cross-reference.
  - `apikey` — pre-formatted plugin license key (`<oauth.secret>-<oauth.id>`). Pass directly to the plugin; never needs to be assembled.
- **Callout** noting the two fields are independent, with a pointer to `/monitor/sites/list/basic` for partners who need to reconcile previously-stored `oauth.id` values against the current `siteid`.
- **WP-CLI activation example** corrected to embed `oauth.id` (12333), not `siteid` (12345) — the old example was internally inconsistent with the new value assignment.
- **Two FAQ entries** at the bottom:
  - "What's the difference between `siteid` and `oauth.id`? Can I assume they're equal?"
  - "How can I reconcile site IDs in my datastore against the Patchstack portal?"

## Test plan
- [x] `npm run build` clean — 190 pages built in 7.85s, no errors
- [x] All embedded `siteid`/`oauth.id`/`apikey` values internally consistent across the page (response example → WP-CLI command → download URL examples)
- [x] No broken links — the `/sites/list/basic` reference points to the existing endpoint documented in the OpenAPI

## Related

- saas#561 — Source fix in `PulseController` (preserves the invariant for the specific Pulse path; merged)
- saas#562 — Removes the unused back-fill command (we explicitly chose not to re-couple the ID spaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)