### PR TITLE
Remove duplicated IP address list from docs article

### DIFF
--- a/src/components/Ips.astro
+++ b/src/components/Ips.astro
@@ -1,3 +1,0 @@
-<p>
-You can find the list of IP addresses that Patchstack uses at <a href="https://patchstack.com/ips-v4/" target="_blank" rel="noopener noreferrer">patchstack.com/ips-v4</a>.
-</p>

--- a/src/components/Ips.astro
+++ b/src/components/Ips.astro
@@ -1,13 +1,3 @@
----
-const response = await fetch("https://patchstack.com/ips-v4/");
-const ips = await response.text();
-const ipList = ips.split("\n").map(ip => ip.trim()).filter(ip => ip.length > 0);
----
-<ul>
-{ipList.map(ip => (
-    <li>{ip}</li>
-))}
-</ul>
 <p>
 You can find the list of IP addresses that Patchstack uses at <a href="https://patchstack.com/ips-v4/" target="_blank" rel="noopener noreferrer">patchstack.com/ips-v4</a>.
 </p>

--- a/src/content/docs/FAQ Troubleshooting/Technical/list-of-ip-addresses-that-patchstack-uses.mdx
+++ b/src/content/docs/FAQ Troubleshooting/Technical/list-of-ip-addresses-that-patchstack-uses.mdx
@@ -10,10 +10,11 @@ updatedAt: "Tue May 16 2023 14:17:00 GMT+0000 (Coordinated Universal Time)"
 sidebar:
   order: 7.3
 ---
-import Ips from '../../../../components/Ips.astro';
-
 Sometimes you need to whitelist our IP addresses in order to avoid your hosting provider or (secondary) firewall blocking our services.
 
-<Ips />
+You can use these two API endpoints to get the list of IP addresses that Patchstack uses:
+
+- [patchstack.com/ips-v4/](https://patchstack.com/ips-v4/)
+- [patchstack.com/ips-v6/](https://patchstack.com/ips-v6/)
 
 Note that we may add and remove IP addresses at any time without notice.

--- a/src/content/docs/FAQ Troubleshooting/Technical/list-of-ip-addresses-that-patchstack-uses.mdx
+++ b/src/content/docs/FAQ Troubleshooting/Technical/list-of-ip-addresses-that-patchstack-uses.mdx
@@ -12,7 +12,8 @@ sidebar:
 ---
 import Ips from '../../../../components/Ips.astro';
 
-Sometimes you need to whitelist these IP addresses in order to avoid your hosting provider or (secondary) firewall blocking our services.
+Sometimes you need to whitelist our IP addresses in order to avoid your hosting provider or (secondary) firewall blocking our services.
+
+<Ips />
 
 Note that we may add and remove IP addresses at any time without notice.
-<Ips />


### PR DESCRIPTION
The article rendered the full IP list (fetched from patchstack.com/ips-v4)
as a bulleted list in addition to linking to the source. The rendered list
could go stale and mismatch the live API. Keep only the link so the IP list
lives in a single source of truth.