### PR TITLE
[ENG-2992] Document GoDaddy staging domains in plugin API key FAQ

### DIFF
--- a/src/content/docs/FAQ Troubleshooting/Technical/can-i-use-the-same-plugin-api-key-for-staging-environment.md
+++ b/src/content/docs/FAQ Troubleshooting/Technical/can-i-use-the-same-plugin-api-key-for-staging-environment.md
@@ -34,7 +34,10 @@ Patchstack allows you to use the same plugin API key for the staging environment
 'wpengine.com',
 'wp-dv',
 'optiserver.co.uk',
-'azurewebsites.net'
+'azurewebsites.net',
+'.myftpupload.com',
+'.mwp.accessdomain.com',
+'store.godaddy.com'
 ```
 
 ### How the staging and production site work with Patchstack?


### PR DESCRIPTION
## Summary
- Adds the three GoDaddy staging URL patterns (`store.godaddy.com`, `.myftpupload.com`, `.mwp.accessdomain.com`) to the "Can I use the same plugin API key for staging environment?" FAQ so the public list matches what the connector actually whitelists.
- Pairs with the connector change on `patchstack/saas` (adds `store.godaddy.com` to the keyword list); the other two patterns were already in code but never documented.

## Test plan
- [ ] Docs build passes locally.
- [ ] FAQ page renders the three new entries inside the existing staging URL phrase block.

Ref ENG-2992