### PR TITLE
[ENG-3134] Rename CMS-specific labeling to "platform" in add-site docs

### DIFF
--- a/src/content/docs/Patchstack App/Sites/adding-a-site.mdx
+++ b/src/content/docs/Patchstack App/Sites/adding-a-site.mdx
@@ -16,9 +16,9 @@ Adding a site to Patchstack is relatively easy. Here is a simple guide on how to
 <Steps>
 1. Navigate to the <a href="https://app.patchstack.com/sites" target="_blank">**Sites**</a> view in Patchstack App
 2. Click on **+ Add new** button. ![](@images/patchstack-sites-add-new.png)
-3. Type your domain name into the popup and choose your CMS: ![](@images/patchstack-add-first-site-dialogue.png)
+3. Type your domain name into the popup and choose your platform: ![](@images/patchstack-add-first-site-dialogue.png)
 4. Click on **Continue to plugin/connector sync**.  
-5. In case you chose WordPress, continue with the steps below. If you chose other CMS, check  <a href="/patchstack-plugin/patchstack-connector/how-to-install-on-drupal/" target="_blank"><b>Drupal instructions</b></a>
+5. In case you chose WordPress, continue with the steps below. If you chose a different platform, check  <a href="/patchstack-plugin/patchstack-connector/how-to-install-on-drupal/" target="_blank"><b>Drupal instructions</b></a>
 6. You will be taken to the next step, where you can follow the next instructions.  ![](@images/patchstack-checking-sync-status.png)
 7. Click **Download latest plugin**
 8. Upload the plugin .zip file to your WordPress site by visiting /wp-admin > Plugins > Add New > Upload Plugin


### PR DESCRIPTION
## Summary

Part of **[ENG-3134](https://linear.app/patchstack/issue/ENG-3134/rename-all-cms-to-all-platforms-across-saas-app)** — _Rename "All CMS" to "All Platforms" across SaaS app_.

The SaaS app PR ([patchstack/saas#859](https://github.com/patchstack/saas/pull/859)) renames the `All CMS` filter default option to `All Platforms` as product scope expands beyond CMS platforms (npm, vibe-coded tools). The Linear issue also asks to **update `docs.patchstack.com` accordingly**.

This is the docs-side change.

## What changed

In **Adding a site** (`Patchstack App/Sites/adding-a-site.mdx`):

- "choose your **CMS**" → "choose your **platform**"
- "If you chose **other CMS**" → "If you chose **a different platform**"

The app's add-site dialog already labels this selection **"Platform:"** (WordPress / Drupal / …), so the docs were out of date and CMS-specific. This rewording matches the live UI and the broadened platform concept.

## Deliberately left unchanged

The literal "All CMS" filter label is not documented in this repo, so there's no direct string to swap. The remaining `CMS` mentions are accurate descriptive uses, not the broadened platform label, and were left as-is:

- `CMS core version` (software overview component list)
- `WordPress CMS` (site software page)
- `CMS of that software` (VDP reports — separate product surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)