### PR TITLE
Document WooCommerce form support for CAPTCHA (ENG-2962)

### DIFF
--- a/src/content/docs/FAQ Troubleshooting/Technical/does-patchstack-work-with-other-captcha-plugins.md
+++ b/src/content/docs/FAQ Troubleshooting/Technical/does-patchstack-work-with-other-captcha-plugins.md
@@ -15,6 +15,6 @@ Patchstack plugin can add either Google ReCAPTCHA or Cloudflare Turnstile to you
 
 Patchstack, by default, has the captcha features turned off. You can pick to which pages you would like to add the capcha -- login, register, forgot password, and comments.
 
-Note that Patchstack's captcha only works with WordPress's built-in forms and not for other plugins forms (like e-commerce registration forms).
+Note that Patchstack's captcha works with WordPress's built-in forms and WooCommerce forms, but not with other plugins' forms.
 
 If you turn this feature on and have a different plugin installed that has the same kind of functionality, you may get locked out of your WordPress site. In this scenario, you'd have to delete either plugin to regain access to your site.

--- a/src/content/docs/Patchstack App/Site Dashboard/Hardening/captcha.md
+++ b/src/content/docs/Patchstack App/Site Dashboard/Hardening/captcha.md
@@ -24,13 +24,15 @@ Patchstack offers two captcha solutions:
 ![](@images/patchstack-captcha-setup.png)
 
 
-Note that our captcha can only be used on the WordPress built-in forms - these are:
+Our captcha can be used on the WordPress built-in forms as well as WooCommerce forms. The WordPress built-in forms are:
 * Commenting forms
 * Login form
 * Registration form
 * Password reset form
 
-**NB!** Patchstack does not offer captcha integrations for other third-party plugins or themes (eg. WooCommerce, Contact Form 7).
+In addition, captcha is supported on WooCommerce forms.
+
+**NB!** Patchstack does not offer captcha integrations for other third-party plugins or themes (eg. Contact Form 7).
 
 To activate captcha on your site, you will have to generate a public key and secret key first.
 The tutorials for creating captcha keys and integrating them with Patchstack can be found below.


### PR DESCRIPTION
## Summary

CAPTCHA now works for WooCommerce forms in addition to WordPress built-in forms, but the docs still stated support was limited to built-in forms (and even listed WooCommerce as *unsupported*). This updates the wording to match current product behavior.

## Changes

- **`Patchstack App/Site Dashboard/Hardening/captcha.md`** — reworded the forms section so it no longer says captcha "can only be used on the WordPress built-in forms"; now covers built-in forms **and WooCommerce forms**, and drops WooCommerce from the "not supported" note.
- **`FAQ Troubleshooting/Technical/does-patchstack-work-with-other-captcha-plugins.md`** — same stale claim (used "e-commerce registration forms" as an unsupported example); updated to state support for built-in **and WooCommerce** forms.

## Notes

Wording is kept generic ("WooCommerce forms") since the exact supported WooCommerce forms weren't specified. Can list them precisely if desired.

Ref: ENG-2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)